### PR TITLE
disable gunicorn access logs

### DIFF
--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -8,3 +8,4 @@ worker_class = "eventlet"
 worker_connections = 1000
 
 errorlog = "/home/vcap/logs/gunicorn_error.log"
+disable_redirect_access_to_syslog = True


### PR DESCRIPTION
they're turning up in syslog, which means they're getting into kibana now