### PR TITLE
Use the public domain route for the Document Download API

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -28,7 +28,7 @@ applications:
 
     NOTIFY_APP_NAME: document-download-frontend
     FLASK_APP: application.py
-    DOCUMENT_DOWNLOAD_API_HOST_NAME: https://document-download-api-{{ environment }}.cloudapps.digital
+    DOCUMENT_DOWNLOAD_API_HOST_NAME: https://{{ hostname }}
     FLASK_ENV: {{ environment }}
     AWS_ACCESS_KEY_ID: {{ AWS_ACCESS_KEY_ID }}
     AWS_SECRET_ACCESS_KEY: {{ AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
After the landing page users are given a link to download the document.
The document is served by the API, so we need to link to it using the
public domain instead of the internal cloudapps.digital route.