### PR TITLE
Remove unused post-my-document endpoint and template

### DIFF
--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -43,11 +43,3 @@ def download_document(service_id, document_id):
         'views/download.html',
         download_link=download_link,
     )
-
-
-@main.route("/post-my-document", methods=['GET'])
-def post_my_document():
-
-    return render_template(
-        'views/post-my-document.html',
-    )

--- a/app/templates/views/download.html
+++ b/app/templates/views/download.html
@@ -7,5 +7,4 @@
   	<p>Save the document so you can refer back to it</p>
   </div>
   <p><a href="{{download_link}}">Download to your device</a></p>
-  <p><a href="{{url_for('main.post_my_document')}}">Can’t print or download the document?</a></p>
 {% endblock %}

--- a/app/templates/views/post-my-document.html
+++ b/app/templates/views/post-my-document.html
@@ -1,5 +1,0 @@
-{% extends "document_download_template.html" %}
-
-{% block fullwidth_content %}
-  <h1 class="heading-large">Post my document</h1>
-{% endblock %}

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -81,16 +81,6 @@ def test_download_document_creates_link_to_actual_doc_from_api(client, mocker, s
     )
 
 
-@pytest.mark.parametrize('view', ['post_my_document'])
-def test_static_pages(client, view):
-    response = client.get(url_for('main.{}'.format(view)))
-
-    assert response.status_code == 200
-    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-
-    assert not page.select_one('meta[name=description]')
-
-
 @pytest.mark.parametrize('view', ['main.landing', 'main.download_document'])
 def test_pages_are_not_indexed(view, client, mocker, sample_service):
     mocker.patch('app.service_api_client.get_service', return_value={'data': sample_service})


### PR DESCRIPTION
The page template doesn't provide any information at the moment and it's unclear whether we'll need it for the initial launch.