### PR TITLE
Prevent documents.* pages from being indexed by search engines

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -82,6 +82,7 @@ def init_app(application):
 
 #  https://www.owasp.org/index.php/List_of_useful_HTTP_headers
 def useful_headers_after_request(response):
+    response.headers.add('X-Robots-Tag', 'noindex, nofollow')
     response.headers.add('X-Frame-Options', 'deny')
     response.headers.add('X-Content-Type-Options', 'nosniff')
     response.headers.add('X-XSS-Protection', '1; mode=block')

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -89,3 +89,23 @@ def test_static_pages(client, view):
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
 
     assert not page.select_one('meta[name=description]')
+
+
+@pytest.mark.parametrize('view', ['main.landing', 'main.download_document'])
+def test_pages_are_not_indexed(view, client, mocker, sample_service):
+    mocker.patch('app.service_api_client.get_service', return_value={'data': sample_service})
+    service_id = uuid4()
+    document_id = uuid4()
+    key = '1234'
+
+    response = client.get(
+        url_for(
+            view,
+            service_id=service_id,
+            document_id=document_id,
+            key=key
+        )
+    )
+
+    assert response.status_code == 200
+    assert response.headers['X-Robots-Tag'] == 'noindex, nofollow'


### PR DESCRIPTION
All of the existing documents pages are user-specific and should never appear in search results.

Setting the X-Robots-Tag header to `noindex, nofollow` prevents search engines from indexing the page or following any links to other pages.

This is different from robots.txt (which prevents pages from being crawled by search engines) since it also stops any documents linked from other websites from showing up in search results.

In order for the header to work the crawling should be allowed by robots.txt (since otherwise the bots don't have a way to see the tag).