### PR TITLE
Add contact info to document download landing page

### DIFF
--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -3,6 +3,7 @@ from notifications_python_client.errors import HTTPError
 
 from app import service_api_client
 from app.main import main
+from app.utils import assess_contact_type
 
 
 @main.route('/d/<base64_uuid:service_id>/<base64_uuid:document_id>', methods=['GET'])
@@ -16,11 +17,14 @@ def landing(service_id, document_id):
     except HTTPError as e:
         abort(e.status_code)
 
+    service_contact_link = service['data']['contact_link']
+    contact_link_type = assess_contact_type(service_contact_link)
     return render_template(
         'views/index.html',
         service_id=service_id,
         service_name=service['data']['name'],
-        service_contact_link=service['data']['contact_link'],  # to be replaced by the contact URL when populated
+        service_contact_link=service_contact_link,
+        contact_link_type=contact_link_type,
         document_id=document_id,
         key=key
     )

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -17,14 +17,14 @@ def landing(service_id, document_id):
     except HTTPError as e:
         abort(e.status_code)
 
-    service_contact_link = service['data']['contact_link']
-    contact_link_type = assess_contact_type(service_contact_link)
+    service_contact_info = service['data']['contact_link']
+    contact_info_type = assess_contact_type(service_contact_info)
     return render_template(
         'views/index.html',
         service_id=service_id,
         service_name=service['data']['name'],
-        service_contact_link=service_contact_link,
-        contact_link_type=contact_link_type,
+        service_contact_info=service_contact_info,
+        contact_info_type=contact_info_type,
         document_id=document_id,
         key=key
     )

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -20,7 +20,7 @@ def landing(service_id, document_id):
         'views/index.html',
         service_id=service_id,
         service_name=service['data']['name'],
-        service_contact_link='https://www.google.com',  # to be replaced by the contact URL when populated
+        service_contact_link=service['data']['contact_link'],  # to be replaced by the contact URL when populated
         document_id=document_id,
         key=key
     )

--- a/app/templates/views/index.html
+++ b/app/templates/views/index.html
@@ -8,7 +8,13 @@
   </p>
   <p>
     If you are unsure if this is a genuine communication,
-    <a href={{ service_contact_link }}> contact {{ service_name }}</a>
+    {% if contact_info_type == "link" %}
+      <a href={{ service_contact_info }}> contact {{ service_name }}</a>
+    {% elif contact_info_type == "email" %}
+      contact {{ service_name }} by emailing <a href={{ "mailto:" + service_contact_info }}>{{service_contact_info}}</a>
+    {% else %}
+      contact {{ service_name }} at {{ service_contact_info }}
+    {% endif %}
     for verification.
   </p>
 {% endblock %}

--- a/app/templates/views/index.html
+++ b/app/templates/views/index.html
@@ -2,19 +2,18 @@
 
 {% block fullwidth_content %}
   <h1 class="heading-large">Download your document</h1>
-  <p>You have been sent a document by {{ service_name or '[SERVICE_NAME]'}}</p>
+  <p>{{ service_name or '[SERVICE_NAME]'}} has sent you a document.</p>
   <p>
     <a href="{{url_for('main.download_document', service_id=service_id, document_id=document_id, key=key)}}" class="button">Continue</a>
   </p>
   <p>
-    If you are unsure if this is a genuine communication,
+    If you're not sure why you've been sent a document,
     {% if contact_info_type == "link" %}
-      <a href={{ service_contact_info }}> contact {{ service_name }}</a>
+      <a href={{ service_contact_info }}> contact {{ service_name }}</a>.
     {% elif contact_info_type == "email" %}
-      contact {{ service_name }} by emailing <a href={{ "mailto:" + service_contact_info }}>{{service_contact_info}}</a>
+      contact {{ service_name }} at <a href={{ "mailto:" + service_contact_info }}>{{service_contact_info}}</a>.
     {% else %}
-      contact {{ service_name }} at {{ service_contact_info }}
+      contact {{ service_name }} on {{ service_contact_info }}.
     {% endif %}
-    for verification.
   </p>
 {% endblock %}

--- a/app/utils.py
+++ b/app/utils.py
@@ -16,12 +16,11 @@ def get_cdn_domain():
 
     return "static-logos.{}".format(domain)
 
-def assess_contact_type(service_contact_link):
-    if re.search(email_regex, service_contact_link):
+
+def assess_contact_type(service_contact_info):
+    if re.search(email_regex, service_contact_info):
         return "email"
-    if re.search(r"^(?:(?:\(?(?:0(?:0|11)\)?[\s-]?\(?|\+)44\)?[\s-]?(?:\(?0\)?[\s-]?)?)|(?:\(?0))(?:(?:\d{5}\)?[\s-]?\d{4,5})|(?:\d{4}\)?[\s-]?(?:\d{5}|\d{3}[\s-]?\d{3}))|(?:\d{3}\)?[\s-]?\d{3}[\s-]?\d{3,4})|(?:\d{2}\)?[\s-]?\d{4}[\s-]?\d{4}))(?:[\s-]?(?:x|ext\.?|\#)\d{3,4})?$", service_contact_link):
-        return "phone"
-    if re.search(r"http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+", service_contact_link):
+    if service_contact_info.startswith("http"):
         return "link"
     else:
-        return "unrecognised"
+        return "other"

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,6 +1,8 @@
 from urllib.parse import urlparse
 
 from flask import current_app
+from notifications_utils.recipients import email_regex
+import re
 
 
 def get_cdn_domain():
@@ -13,3 +15,13 @@ def get_cdn_domain():
     domain = parsed_uri.netloc[len(subdomain + '.'):]
 
     return "static-logos.{}".format(domain)
+
+def assess_contact_type(service_contact_link):
+    if re.search(email_regex, service_contact_link):
+        return "email"
+    if re.search(r"^(?:(?:\(?(?:0(?:0|11)\)?[\s-]?\(?|\+)44\)?[\s-]?(?:\(?0\)?[\s-]?)?)|(?:\(?0))(?:(?:\d{5}\)?[\s-]?\d{4,5})|(?:\d{4}\)?[\s-]?(?:\d{5}|\d{3}[\s-]?\d{3}))|(?:\d{3}\)?[\s-]?\d{3}[\s-]?\d{3,4})|(?:\d{2}\)?[\s-]?\d{4}[\s-]?\d{4}))(?:[\s-]?(?:x|ext\.?|\#)\d{3,4})?$", service_contact_link):
+        return "phone"
+    if re.search(r"http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+", service_contact_link):
+        return "link"
+    else:
+        return "unrecognised"

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -105,7 +105,7 @@ def test_pages_are_not_indexed(view, client, mocker, sample_service):
 @pytest.mark.parametrize('contact_info,type,expected_result', [
     ('https://sample-service.gov.uk', 'link', 'https://sample-service.gov.uk'),
     ('info@sample-service.gov.uk', 'email', 'mailto:info@sample-service.gov.uk'),
-    ('07123456789', 'number', 'contact Sample Service at 07123456789'),
+    ('07123456789', 'number', 'contact Sample Service on 07123456789'),
 
 ])
 def test_landing_page_has_supplier_contact_info(client, mocker, sample_service, contact_info, type, expected_result):

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -1,5 +1,5 @@
-from uuid import uuid4
 from unittest.mock import Mock
+from uuid import uuid4
 
 import pytest
 from bs4 import BeautifulSoup
@@ -99,3 +99,21 @@ def test_pages_are_not_indexed(view, client, mocker, sample_service):
 
     assert response.status_code == 200
     assert response.headers['X-Robots-Tag'] == 'noindex, nofollow'
+
+
+def test_landing_page_has_supplier_contact_info(client, mocker, sample_service):
+    mocker.patch('app.service_api_client.get_service', return_value={'data': sample_service})
+    service_id = uuid4()
+    document_id = uuid4()
+    response = client.get(
+        url_for(
+            'main.landing',
+            service_id=service_id,
+            document_id=document_id,
+            key='1234'
+        )
+    )
+
+    assert response.status_code == 200
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    assert page.findAll(attrs={'href': 'https://sample-service.gov.uk'})

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -2,6 +2,7 @@ from unittest.mock import Mock
 from uuid import uuid4
 
 import pytest
+import re
 from bs4 import BeautifulSoup
 from flask import url_for
 from notifications_python_client.errors import HTTPError
@@ -101,14 +102,14 @@ def test_pages_are_not_indexed(view, client, mocker, sample_service):
     assert response.headers['X-Robots-Tag'] == 'noindex, nofollow'
 
 
-@pytest.mark.parametrize('contact_link,type,expected_result', [
+@pytest.mark.parametrize('contact_info,type,expected_result', [
     ('https://sample-service.gov.uk', 'link', 'https://sample-service.gov.uk'),
     ('info@sample-service.gov.uk', 'email', 'mailto:info@sample-service.gov.uk'),
     ('07123456789', 'number', 'contact Sample Service at 07123456789'),
 
 ])
-def test_landing_page_has_supplier_contact_info(client, mocker, sample_service, contact_link, type, expected_result):
-    service = {'name': 'Sample Service', 'contact_link': contact_link}
+def test_landing_page_has_supplier_contact_info(client, mocker, sample_service, contact_info, type, expected_result):
+    service = {'name': 'Sample Service', 'contact_link': contact_info}
     mocker.patch('app.service_api_client.get_service', return_value={'data': service})
     service_id = uuid4()
     document_id = uuid4()
@@ -124,6 +125,6 @@ def test_landing_page_has_supplier_contact_info(client, mocker, sample_service, 
     assert response.status_code == 200
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
     if type == 'number':
-        assert page.findAll(text=expected_result)
+        assert page.findAll(text=re.compile(expected_result))
     else:
         assert page.findAll(attrs={'href': expected_result})

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -1,4 +1,5 @@
-from app.utils import get_cdn_domain
+from app.utils import get_cdn_domain, assess_contact_type
+import pytest
 
 
 def test_get_cdn_domain_on_localhost(client, mocker):
@@ -11,3 +12,22 @@ def test_get_cdn_domain_on_non_localhost(client, mocker):
     mocker.patch.dict('app.current_app.config', values={'ADMIN_BASE_URL': 'https://some.admintest.com'})
     domain = get_cdn_domain()
     assert domain == 'static-logos.admintest.com'
+
+
+@pytest.mark.parametrize(
+    "contact_info,expected_result",
+    [
+        ("07123456789", "phone"),
+        ("0300 200 3300", "phone"),
+        ("020 3049 7444", "phone"),
+        ("pinkdiamond@homeworld.gem", "email"),
+        ("pink.diamond@digital.diamond-office.gov.uk", "email"),
+        ("https://homeworld.gem/contact-us", "link"),
+        ("http://homeworld.gem/contact-us", "link"),
+        ("www.homeworld.gem", "unrecognised"),
+        ("homeworld.gem", "unrecognised"),
+        ("pinkdiamond", "unrecognised")
+    ]
+)
+def test_assess_contact_type_recognises_email_phone_and_link(contact_info, expected_result):
+    assert assess_contact_type(contact_info) == expected_result

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -17,16 +17,14 @@ def test_get_cdn_domain_on_non_localhost(client, mocker):
 @pytest.mark.parametrize(
     "contact_info,expected_result",
     [
-        ("07123456789", "phone"),
-        ("0300 200 3300", "phone"),
-        ("020 3049 7444", "phone"),
+        ("07123456789", "other"),
         ("pinkdiamond@homeworld.gem", "email"),
         ("pink.diamond@digital.diamond-office.gov.uk", "email"),
         ("https://homeworld.gem/contact-us", "link"),
         ("http://homeworld.gem/contact-us", "link"),
-        ("www.homeworld.gem", "unrecognised"),
-        ("homeworld.gem", "unrecognised"),
-        ("pinkdiamond", "unrecognised")
+        ("www.homeworld.gem", "other"),
+        ("homeworld.gem", "other"),
+        ("pinkdiamond", "other")
     ]
 )
 def test_assess_contact_type_recognises_email_phone_and_link(contact_info, expected_result):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,4 +25,4 @@ def client(app_):
 
 @pytest.fixture(scope='function')
 def sample_service():
-    return {'name': 'Sample Service'}
+    return {'name': 'Sample Service', 'contact_link': 'https://sample-service.gov.uk'}


### PR DESCRIPTION
Part of work for the following story: https://www.pivotaltracker.com/story/show/159490824

Work done:
- contact_link field to service dynamically pulled from service object (instead of static google.com link)  
- type of contact info checked by a helper method (link, email or other. At first it was also checking for phone number but that proved redundant)  
- template displays contact info differently depending on the type

### Screenshots:

#### Link: 
(see bottom left corner for destination)
![screen shot 2018-08-13 at 15 30 29](https://user-images.githubusercontent.com/20957548/44038171-0a5c1948-9f0e-11e8-8827-8c97fe77d9a4.png)

#### Email: 
(see bottom left corner for destination)
![screen shot 2018-08-13 at 15 31 03](https://user-images.githubusercontent.com/20957548/44038180-111dc7c2-9f0e-11e8-8129-5eeab8d53b7b.png)

#### Phone:
![screen shot 2018-08-13 at 14 44 22](https://user-images.githubusercontent.com/20957548/44035549-a9dd719e-9f07-11e8-8791-31238f09d97a.png)


