### PR TITLE
Update notification-utils to the latest version

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -1,7 +1,7 @@
 from urllib.parse import urlparse
 
 from flask import current_app
-from notifications_utils.recipients import email_regex
+from notifications_utils.recipients import EMAIL_REGEX_PATTERN
 import re
 
 
@@ -18,7 +18,7 @@ def get_cdn_domain():
 
 
 def assess_contact_type(service_contact_info):
-    if re.search(email_regex, service_contact_info):
+    if re.search(EMAIL_REGEX_PATTERN, service_contact_info):
         return "email"
     if service_contact_info.startswith("http"):
         return "link"

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -4,12 +4,13 @@
 Flask==1.0.2
 Flask-WTF==0.14.2
 
-gunicorn==19.8.1
+gunicorn==19.7.1  # pyup: ignore, >19.8 breaks eventlet patching
 whitenoise==3.3.1  #manages static assets
-eventlet==0.23.0
+eventlet==0.24.1
+
 notifications-python-client==4.8.2
 
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@29.2.0#egg=notifications-utils==29.2.0
+git+https://github.com/alphagov/notifications-utils.git@30.7.5#egg=notifications-utils==30.7.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,55 +5,56 @@
 Flask==1.0.2
 Flask-WTF==0.14.2
 
-gunicorn==19.8.1
+gunicorn==19.7.1  # pyup: ignore, >19.8 breaks eventlet patching
 whitenoise==3.3.1  #manages static assets
-eventlet==0.23.0
+eventlet==0.24.1
+
 notifications-python-client==4.8.2
 
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@29.2.0#egg=notifications-utils==29.2.0
+git+https://github.com/alphagov/notifications-utils.git@30.7.5#egg=notifications-utils==30.7.5
 
 ## The following requirements were added by pip freeze:
-awscli==1.15.55
-bleach==2.1.3
+awscli==1.16.96
+bleach==3.0.2
 boto3==1.6.16
-botocore==1.10.54
-certifi==2018.4.16
+botocore==1.12.86
+certifi==2018.11.29
 chardet==3.0.4
-click==6.7
+Click==7.0
 colorama==0.3.9
+dnspython==1.16.0
 docopt==0.6.2
 docutils==0.14
 Flask-Redis==0.3.0
-future==0.16.0
-greenlet==0.4.13
-html5lib==1.0.1
-idna==2.7
-itsdangerous==0.24
+future==0.17.1
+greenlet==0.4.15
+idna==2.8
+itsdangerous==1.1.0
 Jinja2==2.10
 jmespath==0.9.3
-MarkupSafe==1.0
-mistune==0.8.3
+MarkupSafe==1.1.0
+mistune==0.8.4
 monotonic==1.5
 orderedset==2.0.1
-phonenumbers==8.9.4
-pyasn1==0.4.3
-PyJWT==1.6.4
+phonenumbers==8.10.2
+pyasn1==0.4.5
+PyJWT==1.7.1
 PyPDF2==1.26.0
-python-dateutil==2.7.3
-python-json-logger==0.1.8
-pytz==2018.4
+python-dateutil==2.7.5
+python-json-logger==0.1.10
+pytz==2018.9
 PyYAML==3.12
-redis==2.10.6
-requests==2.19.1
+redis==3.1.0
+requests==2.21.0
 rsa==3.4.2
 s3transfer==0.1.13
-six==1.11.0
+six==1.12.0
 smartypants==2.0.1
-statsd==3.2.2
-urllib3==1.23
+statsd==3.3.0
+urllib3==1.24.1
 webencodings==0.5.1
 Werkzeug==0.14.1
 WTForms==2.2.1


### PR DESCRIPTION
Downgrades gunicorn to 19.7.1 to fix eventlet patching and updates
insecure dependencies (requests and bleach).