### PR TITLE
unpin patch version of python

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,2 +1,1 @@
-python-3.5.5
-
+python-3.5.x


### PR DESCRIPTION
3.5.5 is removed in the next version of python-buildpack