### PR TITLE
Set instance count at 2

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -4,6 +4,8 @@ applications:
 
   memory: 512M
 
+  instances: 2
+
   buildpack: python_buildpack
 
   {% set hostname={


### PR DESCRIPTION
We were running 1 instance only in production which should
be 2 minimum to help with high availability.