### PR TITLE
Cookies back in the jar

### DIFF
--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -251,3 +251,7 @@ details .arrow {
     cursor: pointer;
   }
 }
+
+#global-cookie-message {
+  display: none;
+}

--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -253,5 +253,5 @@ details .arrow {
 }
 
 #global-cookie-message {
-  display: none;
+  display: none !important;
 }

--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -253,5 +253,6 @@ details .arrow {
 }
 
 #global-cookie-message {
+  // sass-lint:disable no-important
   display: none !important;
 }


### PR DESCRIPTION
> The cookie bar should not be shown / appear at all on the document download site. This should be removed (both wording and the light blue bar). No cookies should be set.
> 
> Currently the wording has gone but the light blue bar still appears if documents.service.gov.uk has not been accessed before in a browser.
>
> We should also make sure that no cookies are being set.

– https://www.pivotaltracker.com/story/show/159434028