### PR TITLE
make sure server header has content

### DIFF
--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -9,4 +9,4 @@ worker_class = "eventlet"
 worker_connections = 1000
 
 errorlog = "/home/vcap/logs/gunicorn_error.log"
-gunicorn.SERVER_SOFTWARE = ''
+gunicorn.SERVER_SOFTWARE = 'None'


### PR DESCRIPTION
an empty field value fails rfc7230 section 3.2[1]. The string `'None'` is about as unexciting as they get. Let's err on the benefit of web safety before someone's random weird browser or request library throws a wobbly

[1] https://tools.ietf.org/html/rfc7230#section-3.2