### PR TITLE
Update document download error pages

### DIFF
--- a/app/templates/error/400.html
+++ b/app/templates/error/400.html
@@ -1,11 +1,20 @@
 {% extends "document_download_template.html" %}
-{% block per_page_title %}Bad Request – GOV.UK Notify{% endblock %}
+{% block per_page_title %}Bad Request{% endblock %}
 {% block main_content %}
 <div class="grid-row">
     <div class="column-two-thirds">
-      <h1 class="heading-medium">
-            {{ message|join(",")}}
+        <h1 class="heading-large">
+          Page not found
         </h1>
+        <p>
+          If you typed the web address, check it is correct.
+        </p>
+        <p>
+          If you pasted the web address, check you copied the entire address.
+        </p>
+        <p>
+          If the web address is correct or you selected a link in an email, contact the team that emailed you.
+        </p>
     </div>
 </div>
 {% endblock %}

--- a/app/templates/error/400.html
+++ b/app/templates/error/400.html
@@ -1,5 +1,5 @@
 {% extends "document_download_template.html" %}
-{% block per_page_title %}Bad Request{% endblock %}
+{% block per_page_title %}Bad Request – GOV.UK Notify{% endblock %}
 {% block main_content %}
 <div class="grid-row">
     <div class="column-two-thirds">

--- a/app/templates/error/400.html
+++ b/app/templates/error/400.html
@@ -1,5 +1,5 @@
 {% extends "document_download_template.html" %}
-{% block per_page_title %}Page not found – GOV.UK{% endblock %}
+{% block page_title %}Page not found – GOV.UK{% endblock %}
 {% block main_content %}
 <div class="grid-row">
     <div class="column-two-thirds">

--- a/app/templates/error/400.html
+++ b/app/templates/error/400.html
@@ -7,13 +7,13 @@
           Page not found
         </h1>
         <p>
+          If you selected a link in an email, contact the sender to tell them you cannot download your file.
+        </p>
+        <p>
           If you typed the web address, check it is correct.
         </p>
         <p>
           If you pasted the web address, check you copied the entire address.
-        </p>
-        <p>
-          If the web address is correct or you selected a link in an email, contact the team that emailed you.
         </p>
     </div>
 </div>

--- a/app/templates/error/400.html
+++ b/app/templates/error/400.html
@@ -1,5 +1,5 @@
 {% extends "document_download_template.html" %}
-{% block per_page_title %}Bad Request{% endblock %}
+{% block per_page_title %}Page not found – GOV.UK{% endblock %}
 {% block main_content %}
 <div class="grid-row">
     <div class="column-two-thirds">

--- a/app/templates/error/401.html
+++ b/app/templates/error/401.html
@@ -10,7 +10,7 @@
         You cannot download your file at the moment.
       </p>
       <p>
-        To report this problem, email <a href="mailto:notify-support@digital.cabinet-office.gov.uk">notify-support@digital.cabinet-office.gov.uk</a>.
+        To report the problem, email <a href="mailto:notify-support@digital.cabinet-office.gov.uk">notify-support@digital.cabinet-office.gov.uk</a>.
       </p>
   </div>
 {% endblock %}

--- a/app/templates/error/401.html
+++ b/app/templates/error/401.html
@@ -1,9 +1,9 @@
 {% extends "document_download_template.html" %}
-{% block per_page_title %}Unauthorized{% endblock %}
+{% block per_page_title %}You are not authorised to see this page – GOV.UK Notify{% endblock %}
 {% block main_content %}
   <div class="grid-row">
     <div class="column-two-thirds">
-    <h1>401</h1>
-    <p>You are not authorized to see this page.</p>
+    <h1>You are not authorised to see this page</h1>
+    <!--<p>TBC</p>-->
   </div>
 {% endblock %}

--- a/app/templates/error/401.html
+++ b/app/templates/error/401.html
@@ -1,16 +1,16 @@
 {% extends "document_download_template.html" %}
-{% block per_page_title %}You are not authorised to see this page{% endblock %}
+{% block per_page_title %}Sorry, there’s a problem with the service{% endblock %}
 {% block main_content %}
   <div class="grid-row">
     <div class="column-two-thirds">
-    <h1 class="heading-large">
-      Sorry, there’s a problem with this service
-    </h1>
-    <p>
-      You cannot download your file at the moment.
-    </p>
-    <p>
-      To report this problem, email <a href="mailto:notify-support@digital.cabinet-office.gov.uk">notify-support@digital.cabinet-office.gov.uk</a>.
-    </p>
+      <h1 class="heading-large">
+        Sorry, there’s a problem with this service
+      </h1>
+      <p>
+        You cannot download your file at the moment.
+      </p>
+      <p>
+        To report this problem, email <a href="mailto:notify-support@digital.cabinet-office.gov.uk">notify-support@digital.cabinet-office.gov.uk</a>.
+      </p>
   </div>
 {% endblock %}

--- a/app/templates/error/401.html
+++ b/app/templates/error/401.html
@@ -1,5 +1,5 @@
 {% extends "document_download_template.html" %}
-{% block per_page_title %}Sorry, there’s a problem with the service{% endblock %}
+{% block page_title %}Sorry, there’s a problem with the service – GOV.UK{% endblock %}
 {% block main_content %}
   <div class="grid-row">
     <div class="column-two-thirds">

--- a/app/templates/error/401.html
+++ b/app/templates/error/401.html
@@ -1,9 +1,16 @@
 {% extends "document_download_template.html" %}
-{% block per_page_title %}You are not authorised to see this page – GOV.UK Notify{% endblock %}
+{% block per_page_title %}You are not authorised to see this page{% endblock %}
 {% block main_content %}
   <div class="grid-row">
     <div class="column-two-thirds">
-    <h1>You are not authorised to see this page</h1>
-    <!--<p>TBC</p>-->
+    <h1 class="heading-large">
+      Sorry, there’s a problem with this service
+    </h1>
+    <p>
+      You cannot download your file at the moment.
+    </p>
+    <p>
+      To report this problem, email <a href="mailto:notify-support@digital.cabinet-office.gov.uk">notify-support@digital.cabinet-office.gov.uk</a>.
+    </p>
   </div>
 {% endblock %}

--- a/app/templates/error/403.html
+++ b/app/templates/error/403.html
@@ -1,14 +1,14 @@
 {% extends "document_download_template.html" %}
-{% block per_page_title %}Forbidden{% endblock %}
+{% block per_page_title %}You are not allowed to see this page – GOV.UK Notify{% endblock %}
 {% block main_content %}
     <div class="grid-row">
       <div class="column-two-thirds">
         <h1 class="heading-large">
-          403
+          You are not allowed to see this page
         </h1>
-        <p>
-          You do not have permission to view this page.
-        </p>
+        <!--<p>
+          TBC
+        </p>-->
       </div>
     </div>
 {% endblock %}

--- a/app/templates/error/403.html
+++ b/app/templates/error/403.html
@@ -10,7 +10,7 @@
         You cannot download your file at the moment.
       </p>
       <p>
-        To report this problem, email <a href="mailto:notify-support@digital.cabinet-office.gov.uk">notify-support@digital.cabinet-office.gov.uk</a>.
+        To report the problem, email <a href="mailto:notify-support@digital.cabinet-office.gov.uk">notify-support@digital.cabinet-office.gov.uk</a>.
       </p>
   </div>
 {% endblock %}

--- a/app/templates/error/403.html
+++ b/app/templates/error/403.html
@@ -1,5 +1,5 @@
 {% extends "document_download_template.html" %}
-{% block per_page_title %}Sorry, there’s a problem with the service{% endblock %}
+{% block page_title %}Sorry, there’s a problem with the service – GOV.UK{% endblock %}
 {% block main_content %}
   <div class="grid-row">
     <div class="column-two-thirds">

--- a/app/templates/error/403.html
+++ b/app/templates/error/403.html
@@ -1,14 +1,16 @@
 {% extends "document_download_template.html" %}
-{% block per_page_title %}You are not allowed to see this page – GOV.UK Notify{% endblock %}
+{% block per_page_title %}Sorry, there’s a problem with the service{% endblock %}
 {% block main_content %}
-    <div class="grid-row">
-      <div class="column-two-thirds">
-        <h1 class="heading-large">
-          You are not allowed to see this page
-        </h1>
-        <!--<p>
-          TBC
-        </p>-->
-      </div>
-    </div>
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <h1 class="heading-large">
+        Sorry, there’s a problem with this service
+      </h1>
+      <p>
+        You cannot download your file at the moment.
+      </p>
+      <p>
+        To report this problem, email <a href="mailto:notify-support@digital.cabinet-office.gov.uk">notify-support@digital.cabinet-office.gov.uk</a>.
+      </p>
+  </div>
 {% endblock %}

--- a/app/templates/error/404.html
+++ b/app/templates/error/404.html
@@ -1,5 +1,5 @@
 {% extends "document_download_template.html" %}
-{% block per_page_title %}Page not found{% endblock %}
+{% block page_title %}Page not found – GOV.UK{% endblock %}
 {% block main_content %}
     <div class="grid-row">
       <div class="column-two-thirds">

--- a/app/templates/error/404.html
+++ b/app/templates/error/404.html
@@ -1,5 +1,5 @@
 {% extends "document_download_template.html" %}
-{% block per_page_title %}Page not found – GOV.UK Notify{% endblock %}
+{% block per_page_title %}Page not found{% endblock %}
 {% block main_content %}
     <div class="grid-row">
       <div class="column-two-thirds">
@@ -13,7 +13,7 @@
           If you pasted the web address, check you copied the entire address.
         </p>
         <p>
-          If the web address is correct or you selected a link or button, <a href="{{ url_for('.support') }}">contact us</a>.
+          If the web address is correct or you selected a link in an email, contact the team that emailed you.
         </p>
       </div>
     </div>

--- a/app/templates/error/404.html
+++ b/app/templates/error/404.html
@@ -1,13 +1,19 @@
 {% extends "document_download_template.html" %}
-{% block per_page_title %}Page could not be found{% endblock %}
+{% block per_page_title %}Page not found – GOV.UK Notify{% endblock %}
 {% block main_content %}
     <div class="grid-row">
       <div class="column-two-thirds">
         <h1 class="heading-large">
-          Page could not be found
+          Page not found
         </h1>
         <p>
-          Check you've entered the correct web address.
+          If you typed the web address, check it is correct.
+        </p>
+        <p>
+          If you pasted the web address, check you copied the entire address.
+        </p>
+        <p>
+          If the web address is correct or you selected a link or button, <a href="{{ url_for('.support') }}">contact us</a>.
         </p>
       </div>
     </div>

--- a/app/templates/error/404.html
+++ b/app/templates/error/404.html
@@ -7,13 +7,13 @@
           Page not found
         </h1>
         <p>
+          If you selected a link in an email, contact the sender to tell them you cannot download your file.
+        </p>
+        <p>
           If you typed the web address, check it is correct.
         </p>
         <p>
           If you pasted the web address, check you copied the entire address.
-        </p>
-        <p>
-          If the web address is correct or you selected a link in an email, contact the team that emailed you.
         </p>
       </div>
     </div>

--- a/app/templates/error/410.html
+++ b/app/templates/error/410.html
@@ -1,5 +1,5 @@
 {% extends "document_download_template.html" %}
-{% block per_page_title %}Page not found – GOV.UK Notify{% endblock %}
+{% block per_page_title %}Page not found{% endblock %}
 {% block main_content %}
     <div class="grid-row">
       <div class="column-two-thirds">
@@ -13,7 +13,7 @@
           If you pasted the web address, check you copied the entire address.
         </p>
         <p>
-          If the web address is correct or you selected a link or button, <a href="{{ url_for('.support') }}">contact us</a>.
+          If the web address is correct or you selected a link in an email, contact the team that emailed you.
         </p>
       </div>
     </div>

--- a/app/templates/error/410.html
+++ b/app/templates/error/410.html
@@ -1,5 +1,5 @@
 {% extends "document_download_template.html" %}
-{% block per_page_title %}Page not found{% endblock %}
+{% block per_page_title %}Page not found – GOV.UK {% endblock %}
 {% block main_content %}
     <div class="grid-row">
       <div class="column-two-thirds">

--- a/app/templates/error/410.html
+++ b/app/templates/error/410.html
@@ -1,13 +1,19 @@
 {% extends "document_download_template.html" %}
-{% block per_page_title %}Page not found{% endblock %}
+{% block per_page_title %}Page not found – GOV.UK Notify{% endblock %}
 {% block main_content %}
     <div class="grid-row">
       <div class="column-two-thirds">
         <h1 class="heading-large">
-          Page could not be found
+          Page not found
         </h1>
         <p>
-          Check you’ve entered the correct web address.
+          If you typed the web address, check it is correct.
+        </p>
+        <p>
+          If you pasted the web address, check you copied the entire address.
+        </p>
+        <p>
+          If the web address is correct or you selected a link or button, <a href="{{ url_for('.support') }}">contact us</a>.
         </p>
       </div>
     </div>

--- a/app/templates/error/410.html
+++ b/app/templates/error/410.html
@@ -7,13 +7,13 @@
           Page not found
         </h1>
         <p>
+          If you selected a link in an email, contact the sender to tell them you cannot download your file.
+        </p>
+        <p>
           If you typed the web address, check it is correct.
         </p>
         <p>
           If you pasted the web address, check you copied the entire address.
-        </p>
-        <p>
-          If the web address is correct or you selected a link in an email, contact the team that emailed you.
         </p>
       </div>
     </div>

--- a/app/templates/error/410.html
+++ b/app/templates/error/410.html
@@ -1,5 +1,5 @@
 {% extends "document_download_template.html" %}
-{% block per_page_title %}Page not found – GOV.UK {% endblock %}
+{% block page_title %}Page not found – GOV.UK {% endblock %}
 {% block main_content %}
     <div class="grid-row">
       <div class="column-two-thirds">

--- a/app/templates/error/500.html
+++ b/app/templates/error/500.html
@@ -1,12 +1,20 @@
 {% extends "document_download_template.html" %}
-{% block per_page_title %}Server error{% endblock %}
+{% block per_page_title %}Sorry, there’s a problem with the service – GOV.UK Notify{% endblock %}
 {% block main_content %}
   <div class="grid-row">
     <div class="column-two-thirds">
       <h1 class="heading-large">
-        Sorry, we’re experiencing technical difficulties
+        Sorry, there’s a problem with GOV.UK Notify
       </h1>
-      <p>Try again later.</p>
+      <p>
+        Try again later.
+      </p>
+      <p>
+        You can check our <a href="https://status.notifications.service.gov.uk">system status</a> page to see if there are any known issues.
+      </p>
+      <p>
+        To report a problem, email <a href="mailto:notify-support@digital.cabinet-office.gov.uk">notify-support@digital.cabinet-office.gov.uk</a>
+      </p>
     </div>
   </div>
 {% endblock %}

--- a/app/templates/error/500.html
+++ b/app/templates/error/500.html
@@ -1,19 +1,16 @@
 {% extends "document_download_template.html" %}
-{% block per_page_title %}Sorry, there’s a problem with the service – GOV.UK Notify{% endblock %}
+{% block per_page_title %}Sorry, there’s a problem with the service{% endblock %}
 {% block main_content %}
   <div class="grid-row">
     <div class="column-two-thirds">
       <h1 class="heading-large">
-        Sorry, there’s a problem with GOV.UK Notify
+        Sorry, there’s a problem with this service
       </h1>
       <p>
+        You cannot download your file at the moment.
+      </p>
+      <p>
         Try again later.
-      </p>
-      <p>
-        You can check our <a href="https://status.notifications.service.gov.uk">system status</a> page to see if there are any known issues.
-      </p>
-      <p>
-        To report a problem, email <a href="mailto:notify-support@digital.cabinet-office.gov.uk">notify-support@digital.cabinet-office.gov.uk</a>
       </p>
     </div>
   </div>

--- a/app/templates/error/500.html
+++ b/app/templates/error/500.html
@@ -1,5 +1,5 @@
 {% extends "document_download_template.html" %}
-{% block per_page_title %}Sorry, there’s a problem with the service{% endblock %}
+{% block page_title %}Sorry, there’s a problem with the service – GOV.UK{% endblock %}
 {% block main_content %}
   <div class="grid-row">
     <div class="column-two-thirds">

--- a/tests/app/test_errorhandlers.py
+++ b/tests/app/test_errorhandlers.py
@@ -9,7 +9,7 @@ def test_bad_url_returns_page_not_found(client):
     response = client.get('/bad_url')
     assert response.status_code == 404
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-    assert page.h1.string.strip() == 'Page could not be found'
+    assert page.h1.string.strip() == 'Page not found'
 
 
 def test_csrf_returns_400(client, mocker, sample_service):
@@ -29,4 +29,4 @@ def test_csrf_returns_400(client, mocker, sample_service):
 
     assert response.status_code == 400
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
-    assert page.h1.string.strip() == 'Something went wrong, please go back and try again.'
+    assert page.h1.string.strip() == 'Page not found'


### PR DESCRIPTION
This PR updates the content for the 400, 401, 403, 404, 410 and 500 document download error pages.

The new content:

- follows the Design system pattern for page titles
- uses English language descriptions instead of error codes in the h1
- adds useful instructions (where possible) so users know what to do next

I've worked with @servingUpAces to understand when users will see these errors and what sensible actions we can suggest.

The error descriptions are more generic than the Notify front-end errors because the users who will see them are citizens/recipients, not Notify users – so they won't be familiar with our service.

I've tried to simplify the language around these errors, using Plain English where possible. The Design system says we should not use "vague, unhelpful words" like maintenance, improvements and technical difficulties.