### PR TITLE
Added an error handler for 400 status code.

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -105,6 +105,7 @@ def register_errorhandlers(application):  # noqa (C901 too complex)
     @application.errorhandler(404)
     @application.errorhandler(403)
     @application.errorhandler(401)
+    @application.errorhandler(400)
     def handle_http_error(error):
         return _error_response(error.code)
 


### PR DESCRIPTION
If for example the key is not copied correctly S3 will respond with a 400, this app was not handling that error properly.