### PR TITLE
Use curly not straight apostrophe on landing page

### DIFF
--- a/app/templates/views/index.html
+++ b/app/templates/views/index.html
@@ -5,7 +5,7 @@
   <p>{{ service_name or '[SERVICE_NAME]'}} sent you a file to download.
 </p>
   <p>
-    If you're not sure why you've been sent a file, or you have any questions,
+    If you’re not sure why you’ve been sent a file, or you have any questions,
     {% if contact_info_type == "link" %}
       <a href={{ service_contact_info }}> contact {{ service_name }}</a>.
     {% elif contact_info_type == "email" %}


### PR DESCRIPTION
> “Smart quotes,” the correct quotation marks and apostrophes, are curly or sloped. […] straight quotes are a vestigial constraint from typewriters when using one key for two different marks helped save space on a keyboard. 

– http://smartquotesforsmartpeople.com/

This commit replaces uses of a straight single quotation mark as an apostrophe with the typographically-correct equivalent.