### PR TITLE
Remove venv from makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,19 +11,12 @@ CF_APP = document-download-frontend
 help:
 	@cat $(MAKEFILE_LIST) | grep -E '^[a-zA-Z_-]+:.*?## .*$$' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-.PHONY: venv
-venv: venv/bin/activate ## Create virtualenv if it does not exist
-
-venv/bin/activate:
-	test -d venv || virtualenv venv -p python3
-	. venv/bin/activate
-
 .PHONY: run
 run:
 	FLASK_APP=application.py FLASK_ENV=development flask run -p 7001
 
 .PHONY: test
-test: venv
+test:
 	find . -name \*.pyc -delete
 	npm install
 	npm run build

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,6 @@ test:
 	npm install
 	npm run build
 	./scripts/run_tests.sh
-	if [[ ! -z $$COVERALLS_REPO_TOKEN ]]; then coveralls; fi
 
 .PHONY: build
 build:
@@ -124,7 +123,6 @@ docker-build:
 .PHONY: test-with-docker
 test-with-docker: docker-build
 	docker run --rm \
-		-e COVERALLS_REPO_TOKEN=${COVERALLS_REPO_TOKEN} \
 		-e CIRCLECI=1 \
 		-e CI_BUILD_NUMBER=${BUILD_NUMBER} \
 		-e CI_BUILD_URL=${BUILD_URL} \
@@ -141,7 +139,6 @@ test-with-docker: docker-build
 build-with-docker: docker-build
 	docker run --rm \
 		-v "`pwd`:/var/project" \
-		-e COVERALLS_REPO_TOKEN=${COVERALLS_REPO_TOKEN} \
 		-e CIRCLECI=1 \
 		-e CI_BUILD_NUMBER=${BUILD_NUMBER} \
 		-e CI_BUILD_URL=${BUILD_URL} \
@@ -158,7 +155,6 @@ build-with-docker: docker-build
 run-with-docker: docker-build
 		docker run --rm \
 		-v "`pwd`:/var/project" \
-		-e COVERALLS_REPO_TOKEN=${COVERALLS_REPO_TOKEN} \
 		-e CIRCLECI=1 \
 		-e CI_BUILD_NUMBER=${BUILD_NUMBER} \
 		-e CI_BUILD_URL=${BUILD_URL} \

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,8 +10,6 @@ pytest-env==0.6.2
 
 requests-mock==1.7.0
 
-coveralls==1.8.2
-
 jinja2-cli[yaml]==0.7.0
 
 beautifulsoup4==4.8.1


### PR DESCRIPTION
Allow developers to control their own virtualenvs like they already do
through virtualenvwrapper.