### PR TITLE
enable running via docker locally

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -26,9 +26,9 @@ class Config(object):
 
 
 class Development(Config):
-    API_HOST_NAME = 'http://localhost:6011'
-    ADMIN_BASE_URL = 'http://localhost:6012'
-    DOCUMENT_DOWNLOAD_API_HOST_NAME = 'http://localhost:7000'
+    API_HOST_NAME = os.environ.get('API_HOST_NAME', 'http://localhost:6011')
+    ADMIN_BASE_URL = os.environ.get('ADMIN_BASE_URL', 'http://localhost:6012')
+    DOCUMENT_DOWNLOAD_API_HOST_NAME = os.environ.get('DOCUMENT_DOWNLOAD_API_HOST_NAME', 'http://localhost:7000')
 
     ADMIN_CLIENT_SECRET = 'dev-notify-secret-key'
 


### PR DESCRIPTION
on paas it just runs through gunicorn.

locally to run through docker it needs to be able to talk to api (by using host.docker.internal, which represents your machine's localhost). also, it needs to broadcast on 0.0.0.0 to allow things outside the docker container (like your browser) to contact it

also remove a bunch of unused env vars from makefile