### PR TITLE
Make page <title>s match <h1>

### DIFF
--- a/app/templates/document_download_template.html
+++ b/app/templates/document_download_template.html
@@ -27,7 +27,7 @@
 {% endblock %}
 
 {% block pageTitle %}
-   GOV.UK - Document download
+   {% block per_page_title %}Document download{% endblock %} – GOV.UK
 {% endblock %}
 
 {% block header %}
@@ -49,4 +49,3 @@
   <script type="text/javascript" src="{{ asset_url('javascripts/main.js') }}"></script>
   <!--<![endif]-->
 {% endblock %}
-

--- a/app/templates/document_download_template.html
+++ b/app/templates/document_download_template.html
@@ -26,8 +26,12 @@
   {% endblock %}
 {% endblock %}
 
+{% set _per_page_title %}
+  {% block per_page_title %}Document Download{% endblock %}
+{% endset %}
+
 {% block pageTitle %}
-   {% block per_page_title %}Document download{% endblock %} – GOV.UK
+  {{ _per_page_title }} – GOV.UK
 {% endblock %}
 
 {% block header %}
@@ -39,6 +43,7 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">{{ _per_page_title }}</h1>
       {% block main_content %}{% endblock %}
     </div>
   </div>

--- a/app/templates/error/400.html
+++ b/app/templates/error/400.html
@@ -1,22 +1,16 @@
 {% extends "document_download_template.html" %}
 {% block per_page_title %}Page not found{% endblock %}
 {% block main_content %}
-<div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-l">
-          Page not found
-        </h1>
-        <div class="govuk-body">
-            <p>
-              If you selected a link in an email, contact the sender to tell them you cannot download your file.
-            </p>
-            <p>
-              If you typed the web address, check it is correct.
-            </p>
-            <p>
-              If you pasted the web address, check you copied the entire address.
-            </p>
-        </div>
-    </div>
-</div>
+  <h1 class="govuk-heading-l">
+    Page not found
+  </h1>
+  <p>
+    If you selected a link in an email, contact the sender to tell them you cannot download your file.
+  </p>
+  <p>
+    If you typed the web address, check it is correct.
+  </p>
+  <p>
+    If you pasted the web address, check you copied the entire address.
+  </p>
 {% endblock %}

--- a/app/templates/error/400.html
+++ b/app/templates/error/400.html
@@ -1,13 +1,13 @@
 {% extends "document_download_template.html" %}
 {% block per_page_title %}Page not found{% endblock %}
 {% block main_content %}
-  <p>
+  <p class="govuk-body">
     If you selected a link in an email, contact the sender to tell them you cannot download your file.
   </p>
-  <p>
+  <p class="govuk-body">
     If you typed the web address, check it is correct.
   </p>
-  <p>
+  <p class="govuk-body">
     If you pasted the web address, check you copied the entire address.
   </p>
 {% endblock %}

--- a/app/templates/error/400.html
+++ b/app/templates/error/400.html
@@ -1,5 +1,5 @@
 {% extends "document_download_template.html" %}
-{% block pageTitle %}Page not found – GOV.UK{% endblock %}
+{% block per_page_title %}Page not found{% endblock %}
 {% block main_content %}
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/app/templates/error/400.html
+++ b/app/templates/error/400.html
@@ -1,9 +1,6 @@
 {% extends "document_download_template.html" %}
 {% block per_page_title %}Page not found{% endblock %}
 {% block main_content %}
-  <h1 class="govuk-heading-l">
-    Page not found
-  </h1>
   <p>
     If you selected a link in an email, contact the sender to tell them you cannot download your file.
   </p>

--- a/app/templates/error/401.html
+++ b/app/templates/error/401.html
@@ -1,5 +1,5 @@
 {% extends "document_download_template.html" %}
-{% block pageTitle %}Sorry, there’s a problem with the service – GOV.UK{% endblock %}
+{% block per_page_title %}Sorry, there’s a problem with the service{% endblock %}
 {% block main_content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/app/templates/error/401.html
+++ b/app/templates/error/401.html
@@ -1,10 +1,10 @@
 {% extends "document_download_template.html" %}
 {% block per_page_title %}Sorry, there’s a problem with the service{% endblock %}
 {% block main_content %}
-  <p>
+  <p class="govuk-body">
     You cannot download your file at the moment.
   </p>
-  <p>
+  <p class="govuk-body">
     To report the problem, email <a href="mailto:notify-support@digital.cabinet-office.gov.uk" class="govuk-link">notify-support@digital.cabinet-office.gov.uk</a>.
   </p>
 {% endblock %}

--- a/app/templates/error/401.html
+++ b/app/templates/error/401.html
@@ -1,6 +1,7 @@
 {% extends "document_download_template.html" %}
 {% block per_page_title %}Sorry, there’s a problem with the service{% endblock %}
 {% block main_content %}
+<<<<<<< HEAD
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">
@@ -15,4 +16,15 @@
           </p>
       </div>
   </div>
+=======
+  <h1 class="heading-large">
+    Sorry, there’s a problem with this service
+  </h1>
+  <p>
+    You cannot download your file at the moment.
+  </p>
+  <p>
+    To report the problem, email <a href="mailto:notify-support@digital.cabinet-office.gov.uk">notify-support@digital.cabinet-office.gov.uk</a>.
+  </p>
+>>>>>>> Remove double-nested 2/3 columns on error page
 {% endblock %}

--- a/app/templates/error/401.html
+++ b/app/templates/error/401.html
@@ -1,30 +1,10 @@
 {% extends "document_download_template.html" %}
 {% block per_page_title %}Sorry, there’s a problem with the service{% endblock %}
 {% block main_content %}
-<<<<<<< HEAD
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l">
-        Sorry, there’s a problem with this service
-      </h1>
-      <div class="govuk-body">
-          <p>
-            You cannot download your file at the moment.
-          </p>
-          <p>
-            To report the problem, email <a href="mailto:notify-support@digital.cabinet-office.gov.uk" class="govuk-link">notify-support@digital.cabinet-office.gov.uk</a>.
-          </p>
-      </div>
-  </div>
-=======
-  <h1 class="heading-large">
-    Sorry, there’s a problem with this service
-  </h1>
   <p>
     You cannot download your file at the moment.
   </p>
   <p>
-    To report the problem, email <a href="mailto:notify-support@digital.cabinet-office.gov.uk">notify-support@digital.cabinet-office.gov.uk</a>.
+    To report the problem, email <a href="mailto:notify-support@digital.cabinet-office.gov.uk" class="govuk-link">notify-support@digital.cabinet-office.gov.uk</a>.
   </p>
->>>>>>> Remove double-nested 2/3 columns on error page
 {% endblock %}

--- a/app/templates/error/403.html
+++ b/app/templates/error/403.html
@@ -1,9 +1,6 @@
 {% extends "document_download_template.html" %}
 {% block per_page_title %}Sorry, there’s a problem with the service{% endblock %}
 {% block main_content %}
-  <h1 class="govuk-heading-l">
-    Sorry, there’s a problem with this service
-  </h1>
   <p>
     You cannot download your file at the moment.
   </p>

--- a/app/templates/error/403.html
+++ b/app/templates/error/403.html
@@ -1,5 +1,5 @@
 {% extends "document_download_template.html" %}
-{% block pageTitle %}Sorry, there’s a problem with the service – GOV.UK{% endblock %}
+{% block per_page_title %}Sorry, there’s a problem with the service{% endblock %}
 {% block main_content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/app/templates/error/403.html
+++ b/app/templates/error/403.html
@@ -1,18 +1,13 @@
 {% extends "document_download_template.html" %}
 {% block per_page_title %}Sorry, there’s a problem with the service{% endblock %}
 {% block main_content %}
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l">
-        Sorry, there’s a problem with this service
-      </h1>
-      <div class="govuk-body">
-          <p>
-            You cannot download your file at the moment.
-          </p>
-          <p>
-            To report the problem, email <a href="mailto:notify-support@digital.cabinet-office.gov.uk" class="govuk-link">notify-support@digital.cabinet-office.gov.uk</a>.
-          </p>
-      </div>
-  </div>
+  <h1 class="govuk-heading-l">
+    Sorry, there’s a problem with this service
+  </h1>
+  <p>
+    You cannot download your file at the moment.
+  </p>
+  <p>
+    To report the problem, email <a href="mailto:notify-support@digital.cabinet-office.gov.uk" class="govuk-link">notify-support@digital.cabinet-office.gov.uk</a>.
+  </p>
 {% endblock %}

--- a/app/templates/error/403.html
+++ b/app/templates/error/403.html
@@ -1,10 +1,10 @@
 {% extends "document_download_template.html" %}
 {% block per_page_title %}Sorry, there’s a problem with the service{% endblock %}
 {% block main_content %}
-  <p>
+  <p class="govuk-body">
     You cannot download your file at the moment.
   </p>
-  <p>
+  <p class="govuk-body">
     To report the problem, email <a href="mailto:notify-support@digital.cabinet-office.gov.uk" class="govuk-link">notify-support@digital.cabinet-office.gov.uk</a>.
   </p>
 {% endblock %}

--- a/app/templates/error/404.html
+++ b/app/templates/error/404.html
@@ -1,5 +1,5 @@
 {% extends "document_download_template.html" %}
-{% block pageTitle %}Page not found – GOV.UK{% endblock %}
+{% block per_page_title %}Page not found{% endblock %}
 {% block main_content %}
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/app/templates/error/404.html
+++ b/app/templates/error/404.html
@@ -1,22 +1,16 @@
 {% extends "document_download_template.html" %}
 {% block per_page_title %}Page not found{% endblock %}
 {% block main_content %}
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-l">
-          Page not found
-        </h1>
-        <div class="govuk-body">
-          <p>
-            If you selected a link in an email, contact the sender to tell them you cannot download your file.
-          </p>
-          <p>
-            If you typed the web address, check it is correct.
-          </p>
-          <p>
-            If you pasted the web address, check you copied the entire address.
-          </p>
-        </div>
-      </div>
-    </div>
+  <h1 class="govuk-heading-l">
+    Page not found
+  </h1>
+  <p>
+    If you selected a link in an email, contact the sender to tell them you cannot download your file.
+  </p>
+  <p>
+    If you typed the web address, check it is correct.
+  </p>
+  <p>
+    If you pasted the web address, check you copied the entire address.
+  </p>
 {% endblock %}

--- a/app/templates/error/404.html
+++ b/app/templates/error/404.html
@@ -1,13 +1,13 @@
 {% extends "document_download_template.html" %}
 {% block per_page_title %}Page not found{% endblock %}
 {% block main_content %}
-  <p>
+  <p class="govuk-body">
     If you selected a link in an email, contact the sender to tell them you cannot download your file.
   </p>
-  <p>
+  <p class="govuk-body">
     If you typed the web address, check it is correct.
   </p>
-  <p>
+  <p class="govuk-body">
     If you pasted the web address, check you copied the entire address.
   </p>
 {% endblock %}

--- a/app/templates/error/404.html
+++ b/app/templates/error/404.html
@@ -1,9 +1,6 @@
 {% extends "document_download_template.html" %}
 {% block per_page_title %}Page not found{% endblock %}
 {% block main_content %}
-  <h1 class="govuk-heading-l">
-    Page not found
-  </h1>
   <p>
     If you selected a link in an email, contact the sender to tell them you cannot download your file.
   </p>

--- a/app/templates/error/410.html
+++ b/app/templates/error/410.html
@@ -1,22 +1,16 @@
 {% extends "document_download_template.html" %}
 {% block per_page_title %}Page not found{% endblock %}
 {% block main_content %}
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-l">
-          Page not found
-        </h1>
-        <div class="govuk-body">
-          <p>
-            If you selected a link in an email, contact the sender to tell them you cannot download your file.
-          </p>
-          <p>
-            If you typed the web address, check it is correct.
-          </p>
-          <p>
-            If you pasted the web address, check you copied the entire address.
-          </p>
-        </div>
-      </div>
-    </div>
+  <h1 class="govuk-heading-l">
+    Page not found
+  </h1>
+  <p>
+    If you selected a link in an email, contact the sender to tell them you cannot download your file.
+  </p>
+  <p>
+    If you typed the web address, check it is correct.
+  </p>
+  <p>
+    If you pasted the web address, check you copied the entire address.
+  </p>
 {% endblock %}

--- a/app/templates/error/410.html
+++ b/app/templates/error/410.html
@@ -1,13 +1,13 @@
 {% extends "document_download_template.html" %}
 {% block per_page_title %}Page not found{% endblock %}
 {% block main_content %}
-  <p>
+  <p class="govuk-body">
     If you selected a link in an email, contact the sender to tell them you cannot download your file.
   </p>
-  <p>
+  <p class="govuk-body">
     If you typed the web address, check it is correct.
   </p>
-  <p>
+  <p class="govuk-body">
     If you pasted the web address, check you copied the entire address.
   </p>
 {% endblock %}

--- a/app/templates/error/410.html
+++ b/app/templates/error/410.html
@@ -1,5 +1,5 @@
 {% extends "document_download_template.html" %}
-{% block pageTitle %}Page not found – GOV.UK {% endblock %}
+{% block per_page_title %}Page not found{% endblock %}
 {% block main_content %}
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/app/templates/error/410.html
+++ b/app/templates/error/410.html
@@ -1,9 +1,6 @@
 {% extends "document_download_template.html" %}
 {% block per_page_title %}Page not found{% endblock %}
 {% block main_content %}
-  <h1 class="govuk-heading-l">
-    Page not found
-  </h1>
   <p>
     If you selected a link in an email, contact the sender to tell them you cannot download your file.
   </p>

--- a/app/templates/error/500.html
+++ b/app/templates/error/500.html
@@ -1,19 +1,13 @@
 {% extends "document_download_template.html" %}
 {% block per_page_title %}Sorry, there’s a problem with the service{% endblock %}
 {% block main_content %}
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l">
-        Sorry, there’s a problem with this service
-      </h1>
-      <div class="govuk-body">
-        <p>
-          You cannot download your file at the moment.
-        </p>
-        <p>
-          Try again later.
-        </p>
-      </div>
-    </div>
-  </div>
+  <h1 class="govuk-heading-l">
+    Sorry, there’s a problem with this service
+  </h1>
+  <p>
+    You cannot download your file at the moment.
+  </p>
+  <p>
+    Try again later.
+  </p>
 {% endblock %}

--- a/app/templates/error/500.html
+++ b/app/templates/error/500.html
@@ -1,9 +1,6 @@
 {% extends "document_download_template.html" %}
 {% block per_page_title %}Sorry, there’s a problem with the service{% endblock %}
 {% block main_content %}
-  <h1 class="govuk-heading-l">
-    Sorry, there’s a problem with this service
-  </h1>
   <p>
     You cannot download your file at the moment.
   </p>

--- a/app/templates/error/500.html
+++ b/app/templates/error/500.html
@@ -1,5 +1,5 @@
 {% extends "document_download_template.html" %}
-{% block pageTitle %}Sorry, there’s a problem with the service – GOV.UK{% endblock %}
+{% block per_page_title %}Sorry, there’s a problem with the service{% endblock %}
 {% block main_content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/app/templates/error/500.html
+++ b/app/templates/error/500.html
@@ -1,10 +1,10 @@
 {% extends "document_download_template.html" %}
 {% block per_page_title %}Sorry, there’s a problem with the service{% endblock %}
 {% block main_content %}
-  <p>
+  <p class="govuk-body">
     You cannot download your file at the moment.
   </p>
-  <p>
+  <p class="govuk-body">
     Try again later.
   </p>
 {% endblock %}

--- a/app/templates/views/download.html
+++ b/app/templates/views/download.html
@@ -5,30 +5,26 @@
 {% endblock %}
 
 {% block main_content %}
-  <h1 class="govuk-heading-l">Download your file</h1>
+  <p>
+    Save your file somewhere you can find it. You may need to print it or show it to someone later.
+  </p>
 
-  <div class="govuk-body">
-    <p>
-      Save your file somewhere you can find it. You may need to print it or show it to someone later.
-    </p>
+  <p>
+    Check the email that {{ service_name or '[SERVICE_NAME]'}} sent you for more information.
+  </p>
 
-    <p>
-      Check the email that {{ service_name or '[SERVICE_NAME]'}} sent you for more information.
-    </p>
+  <p>
+    <a href="{{download_link}}" download class="govuk-link">Download this file to your device</a>
+  </p>
 
-    <p>
-      <a href="{{download_link}}" download class="govuk-link">Download this file to your device</a>
-    </p>
-
-    <p>
-      If you have any questions,
-      {% if contact_info_type == "link" %}
-        <a href={{ service_contact_info }} class="govuk-link"> contact {{ service_name }}</a>.
-      {% elif contact_info_type == "email" %}
-        email <a href={{ "mailto:" + service_contact_info }} class="govuk-link">{{service_contact_info}}</a>.
-      {% else %}
-        call {{ service_contact_info }}.
-      {% endif %}
-    </p>
-  </div>
+  <p>
+    If you have any questions,
+    {% if contact_info_type == "link" %}
+      <a href={{ service_contact_info }} class="govuk-link"> contact {{ service_name }}</a>.
+    {% elif contact_info_type == "email" %}
+      email <a href={{ "mailto:" + service_contact_info }} class="govuk-link">{{service_contact_info}}</a>.
+    {% else %}
+      call {{ service_contact_info }}.
+    {% endif %}
+  </p>
 {% endblock %}

--- a/app/templates/views/download.html
+++ b/app/templates/views/download.html
@@ -5,19 +5,19 @@
 {% endblock %}
 
 {% block main_content %}
-  <p>
+  <p class="govuk-body">
     Save your file somewhere you can find it. You may need to print it or show it to someone later.
   </p>
 
-  <p>
+  <p class="govuk-body">
     Check the email that {{ service_name or '[SERVICE_NAME]'}} sent you for more information.
   </p>
 
-  <p>
+  <p class="govuk-body">
     <a href="{{download_link}}" download class="govuk-link">Download this file to your device</a>
   </p>
 
-  <p>
+  <p class="govuk-body">
     If you have any questions,
     {% if contact_info_type == "link" %}
       <a href={{ service_contact_info }} class="govuk-link"> contact {{ service_name }}</a>.

--- a/app/templates/views/download.html
+++ b/app/templates/views/download.html
@@ -1,5 +1,9 @@
 {% extends "document_download_template.html" %}
 
+{% block per_page_title %}
+  Download your file
+{% endblock %}
+
 {% block main_content %}
   <h1 class="govuk-heading-l">Download your file</h1>
 

--- a/app/templates/views/index.html
+++ b/app/templates/views/index.html
@@ -2,6 +2,10 @@
 
 {% from "components/button/macro.njk" import govukButton %}
 
+{% block per_page_title %}
+  You have a file to download
+{% endblock %}
+
 {% block main_content %}
   <h1 class="govuk-heading-l">You have a file to download</h1>
   <div class="govuk-body">

--- a/app/templates/views/index.html
+++ b/app/templates/views/index.html
@@ -7,8 +7,8 @@
 {% endblock %}
 
 {% block main_content %}
-  <p>{{ service_name or '[SERVICE_NAME]'}} sent you a file to download.</p>
-  <p>
+  <p class="govuk-body">{{ service_name or '[SERVICE_NAME]'}} sent you a file to download.</p>
+  <p class="govuk-body">
     If you’re not sure why you’ve been sent a file, or you have any questions,
     {% if contact_info_type == "link" %}
       <a href={{ service_contact_info }} class="govuk-link"> contact {{ service_name }}</a>.
@@ -18,7 +18,7 @@
       call {{ service_contact_info }}.
     {% endif %}
   </p>
-  <p>
+  <p class="govuk-body">
     {{ govukButton({
       "href": url_for('main.download_document', service_id=service_id, document_id=document_id, key=key),
       "text": "Continue",

--- a/app/templates/views/index.html
+++ b/app/templates/views/index.html
@@ -7,28 +7,22 @@
 {% endblock %}
 
 {% block main_content %}
-  <h1 class="govuk-heading-l">You have a file to download</h1>
-  <div class="govuk-body">
-    <p>
-      {{ service_name or '[SERVICE_NAME]'}} sent you a file to download.
-    </p>
-    <p>
-      If you’re not sure why you’ve been sent a file, or you have any questions,
-      {% if contact_info_type == "link" %}
-        <a href={{ service_contact_info }} class="govuk-link"> contact {{ service_name }}</a>.
-      {% elif contact_info_type == "email" %}
-        email <a href={{ "mailto:" + service_contact_info }} class="govuk-link">{{service_contact_info}}</a>.
-      {% else %}
-        call {{ service_contact_info }}.
-      {% endif %}
-    </p>
-    <p>
-
+  <p>{{ service_name or '[SERVICE_NAME]'}} sent you a file to download.</p>
+  <p>
+    If you’re not sure why you’ve been sent a file, or you have any questions,
+    {% if contact_info_type == "link" %}
+      <a href={{ service_contact_info }} class="govuk-link"> contact {{ service_name }}</a>.
+    {% elif contact_info_type == "email" %}
+      email <a href={{ "mailto:" + service_contact_info }} class="govuk-link">{{service_contact_info}}</a>.
+    {% else %}
+      call {{ service_contact_info }}.
+    {% endif %}
+  </p>
+  <p>
     {{ govukButton({
       "href": url_for('main.download_document', service_id=service_id, document_id=document_id, key=key),
       "text": "Continue",
       "element": "a",
     }) }}
-    </p>
-  </div>
+  </p>
 {% endblock %}

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,4 @@
+def normalize_spaces(input):
+    if isinstance(input, str):
+        return ' '.join(input.split())
+    return normalize_spaces(' '.join(item.text for item in input))


### PR DESCRIPTION
It’s good accessibility practice for the page title to start with the same text as the H1 of the page.

Also does some refactoring of the page templates to tidy up and simplify the code (no functional changes).