### PR TITLE
Fix href values without quotes

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,4 +1,3 @@
 /version.py
-/templates/govuk_template.html
 /static
 

--- a/app/templates/views/download.html
+++ b/app/templates/views/download.html
@@ -22,7 +22,7 @@
     {% if contact_info_type == "link" %}
       <a href="{{ service_contact_info }}" class="govuk-link"> contact {{ service_name }}</a>.
     {% elif contact_info_type == "email" %}
-      email <a href="{{ "mailto:" + service_contact_info }}" class="govuk-link">{{service_contact_info}}</a>.
+      email <a href="mailto:{{ service_contact_info }}" class="govuk-link">{{service_contact_info}}</a>.
     {% else %}
       call {{ service_contact_info }}.
     {% endif %}

--- a/app/templates/views/download.html
+++ b/app/templates/views/download.html
@@ -20,9 +20,9 @@
   <p class="govuk-body">
     If you have any questions,
     {% if contact_info_type == "link" %}
-      <a href={{ service_contact_info }} class="govuk-link"> contact {{ service_name }}</a>.
+      <a href="{{ service_contact_info }}" class="govuk-link"> contact {{ service_name }}</a>.
     {% elif contact_info_type == "email" %}
-      email <a href={{ "mailto:" + service_contact_info }} class="govuk-link">{{service_contact_info}}</a>.
+      email <a href="{{ "mailto:" + service_contact_info }}" class="govuk-link">{{service_contact_info}}</a>.
     {% else %}
       call {{ service_contact_info }}.
     {% endif %}

--- a/app/templates/views/index.html
+++ b/app/templates/views/index.html
@@ -13,7 +13,7 @@
     {% if contact_info_type == "link" %}
       <a href="{{ service_contact_info }}" class="govuk-link"> contact {{ service_name }}</a>.
     {% elif contact_info_type == "email" %}
-      email <a href="{{ "mailto:" + service_contact_info }}" class="govuk-link">{{service_contact_info}}</a>.
+      email <a href="mailto:{{ service_contact_info }}" class="govuk-link">{{service_contact_info}}</a>.
     {% else %}
       call {{ service_contact_info }}.
     {% endif %}

--- a/app/templates/views/index.html
+++ b/app/templates/views/index.html
@@ -11,9 +11,9 @@
   <p class="govuk-body">
     If you’re not sure why you’ve been sent a file, or you have any questions,
     {% if contact_info_type == "link" %}
-      <a href={{ service_contact_info }} class="govuk-link"> contact {{ service_name }}</a>.
+      <a href="{{ service_contact_info }}" class="govuk-link"> contact {{ service_name }}</a>.
     {% elif contact_info_type == "email" %}
-      email <a href={{ "mailto:" + service_contact_info }} class="govuk-link">{{service_contact_info}}</a>.
+      email <a href="{{ "mailto:" + service_contact_info }}" class="govuk-link">{{service_contact_info}}</a>.
     {% else %}
       call {{ service_contact_info }}.
     {% endif %}


### PR DESCRIPTION
@nickcolley noticed that a few of the `href`s on our pages have values without quotes (see https://github.com/alphagov/document-download-frontend/pull/53#discussion_r374058894).

This is a fix for that.

Also removes a reference to the `govuk_template.html` file, which is no longer used.