### PR TITLE
bump all requirements

### DIFF
--- a/application.py
+++ b/application.py
@@ -12,4 +12,4 @@ STATIC_URL = 'static/'
 app = Flask('app')
 
 create_app(app)
-application = WhiteNoise(app, STATIC_ROOT, STATIC_URL)
+app.wsgi_app = WhiteNoise(app.wsgi_app, STATIC_ROOT, STATIC_URL)

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -1,14 +1,14 @@
 # Run `make freeze-requirements` to update requirements.txt
 # with package version changes made in requirements-app.txt
 
-Flask==1.0.3
+Flask==1.1.1
 Flask-WTF==0.14.2
 
-gunicorn==19.7.1  # pyup: ignore, >19.8 breaks eventlet patching
-whitenoise==4.1.2  #manages static assets
-eventlet==0.24.1
+gunicorn==20.0.4
+whitenoise==5.0.1  #manages static assets
+eventlet==0.25.1
 
-notifications-python-client==5.3.0
+notifications-python-client==5.5.0
 
 # PaaS
 awscli-cwlogs>=1.4,<1.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,14 +2,14 @@
 # Run `make freeze-requirements` to update requirements.txt
 # with package version changes made in requirements-app.txt
 
-Flask==1.0.3
+Flask==1.1.1
 Flask-WTF==0.14.2
 
-gunicorn==19.7.1  # pyup: ignore, >19.8 breaks eventlet patching
-whitenoise==4.1.2  #manages static assets
-eventlet==0.24.1
+gunicorn==20.0.4
+whitenoise==5.0.1  #manages static assets
+eventlet==0.25.1
 
-notifications-python-client==5.3.0
+notifications-python-client==5.5.0
 
 # PaaS
 awscli-cwlogs>=1.4,<1.5
@@ -48,7 +48,7 @@ python-dateutil==2.8.1
 python-json-logger==0.1.11
 pytz==2019.3
 PyYAML==5.2
-redis==3.4.0
+redis==3.4.1
 requests==2.22.0
 rsa==3.4.2
 s3transfer==0.3.2


### PR DESCRIPTION
notably gunicorn. whitenoise is a major version bump but only because it drops support for python 3. also fix whitenoise configuration as per https://github.com/alphagov/notifications-admin/pull/2546/files