### PR TITLE
refer to application rather than app

### DIFF
--- a/application.py
+++ b/application.py
@@ -9,7 +9,7 @@ PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
 STATIC_ROOT = os.path.join(PROJECT_ROOT, 'app', 'static')
 STATIC_URL = 'static/'
 
-app = Flask('app')
+application = Flask('app')
 
-create_app(app)
-app.wsgi_app = WhiteNoise(app.wsgi_app, STATIC_ROOT, STATIC_URL)
+create_app(application)
+application.wsgi_app = WhiteNoise(application.wsgi_app, STATIC_ROOT, STATIC_URL)


### PR DESCRIPTION
in line with what admin does.

tested by running gunicorn locally, seems to fix it

gunicorn looks for a variable called `application` if you pass it a file rather than a full wsgi app in its args http://docs.gunicorn.org/en/stable/run.html#django