### PR TITLE
Send doc download frontend logs to logit

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -18,6 +18,9 @@ applications:
     - route: document-download-frontend-{{ environment }}.cloudapps.digital
     - route: {{ hostname }}
 
+  services:
+    - logit-ssl-syslog-drain
+
   health-check-type: http
   health-check-http-endpoint: '/_status'
 


### PR DESCRIPTION
This is the only app we aren't doing this for.

Copying what we do in https://github.com/alphagov/document-download-api/blob/master/manifest.yml.j2#L24