### PR TITLE
Add a new page when trying to view a file that doesn't exist

### DIFF
--- a/app/templates/views/file_unavailable.html
+++ b/app/templates/views/file_unavailable.html
@@ -1,0 +1,23 @@
+{% extends "document_download_template.html" %}
+
+{% block per_page_title %}
+  No longer available
+{% endblock %}
+
+{% block main_content %}
+  <p class="govuk-body">
+    The file you are looking for has expired or been deleted.
+  </p>
+
+  <p class="govuk-body">
+    If you have any questions,
+    {% if contact_info_type == "link" %}
+      <a href="{{ service_contact_info }}" class="govuk-link"> contact {{ service_name }}</a>.
+    {% elif contact_info_type == "email" %}
+      email <a href="mailto:{{ service_contact_info }}" class="govuk-link">{{service_contact_info}}</a>.
+    {% else %}
+      call {{ service_contact_info }}.
+    {% endif %}
+  </p>
+
+{% endblock %}

--- a/tests/app/test_errorhandlers.py
+++ b/tests/app/test_errorhandlers.py
@@ -17,6 +17,7 @@ def test_csrf_returns_400(client, mocker, sample_service):
     csrf_err = CSRFError('400 Bad Request: The CSRF tokens do not match.')
     mocker.patch('app.service_api_client.get_service', return_value={'data': sample_service})
     mocker.patch('app.main.views.index.render_template', side_effect=csrf_err)
+    mocker.patch('app.main.views.index.is_file_available', return_value=True)
 
     response = client.get(
         url_for(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+import requests_mock
 from flask import Flask
 
 from app import create_app
@@ -26,3 +27,9 @@ def client(app_):
 @pytest.fixture(scope='function')
 def sample_service():
     return {'name': 'Sample Service', 'contact_link': 'https://sample-service.gov.uk'}
+
+
+@pytest.fixture
+def rmock():
+    with requests_mock.mock() as rmock:
+        yield rmock


### PR DESCRIPTION
If a file was not in S3, the user would see an S3 error when clicking on the link to download the file. `document-download-api` now has an endpoint to check if a file is in S3, which means that when a user clicks an email link, we can check if the file is available and only show the page to download it if it is.

If there was an unexpected error when checking if the file was available, the error handlers will handle it and `document-download-api` logs a message so we can investigate.

[Pivotal story](https://www.pivotaltracker.com/story/show/172199088)

**Depends on**
- [x] https://github.com/alphagov/document-download-api/pull/120