### PR TITLE
Show 404 page when visiting link with wrong encryption key

### DIFF
--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -83,9 +83,14 @@ def is_file_available(service_id, document_id, key):
     )
     response = requests.get(check_file_url)
 
-    # Show 404 if decryption key is missing / invalid
-    if response.status_code == 400 and 'decryption key' in response.json().get('Error', ''):
-        abort(404)
+    if response.status_code == 400:
+        error_msg = response.json().get('error', '')
+        # If the decryption key is missing or can't be decoded using `urlsafe_b64decode`,
+        # the error message will contain 'decryption key'.
+        # If the decryption key is wrong, the error message is 'Forbidden'
+        if 'decryption key' in error_msg or 'Forbidden' in error_msg:
+            abort(404)
+
     # Let the `500` error handler handle unexpected errors from doc-download-api
     response.raise_for_status()
 


### PR DESCRIPTION
We had accounted for the case where someone visits a link with no key or a key that can't be decoded using `urlsafe_b64decode`. However, if there is a key and that key can be decoded using `urlsafe_b64decode`, the error returned to document-download-api by S3 is a `Forbidden` error which wasn't being taken into account.

If S3 gives a `Forbidden` error (because the key is wrong) we now show the `404` page. This page already contains instructions about checking the link.

The JSON returned from document-download-api's endpoint to check if a file is in S3 contains the key `error`, not `Error`, so this also fixes that.