### PR TITLE
Attempt to fix dnspython/gunicorn error

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -6,7 +6,7 @@ Flask-WTF==0.14.3
 
 gunicorn==20.0.4
 whitenoise==5.0.1  #manages static assets
-eventlet==0.25.1
+eventlet==0.26.1
 
 notifications-python-client==5.5.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ Flask-WTF==0.14.3
 
 gunicorn==20.0.4
 whitenoise==5.0.1  #manages static assets
-eventlet==0.25.1
+eventlet==0.26.1
 
 notifications-python-client==5.5.0
 
@@ -27,7 +27,7 @@ certifi==2020.12.5
 chardet==3.0.4
 click==7.1.2
 colorama==0.4.3
-dnspython==2.0.0
+dnspython==1.16.0
 docopt==0.6.2
 docutils==0.15.2
 flask-redis==0.4.0


### PR DESCRIPTION
We are seeing gunicorn errors since upgrading some packages, including
dnspython to 2.0.0. Can't replicate locally easily so will try this fix
that may have worked on a different app and see if it works.

Based on
https://github.com/alphagov/notifications-api/commit/baebc5bdafa536c119ce3185c506201e76026abb