### PR TITLE
Increase memory from 512MB to 1G

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -2,7 +2,7 @@
 applications:
 - name: document-download-frontend
 
-  memory: 512M
+  memory: 1G
 
   instances: 2
 


### PR DESCRIPTION
This app has been skirting around the 95% memory mark for the last 2
months. There is a chance this is causing the occasional error. We don't
have proper evidence for this but it is a hypothesis that we can quickly
test.

It may be benficial to bump the memory regardless of whether it fixes
occasional errors, just to give the app some more headroom in case it's
memory requirements go up very slightly in the future.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)
