### PR TITLE
Bump gulp & gulp-sass to latest versions

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,7 +20,7 @@ plugins.jshint = require('gulp-jshint');
 plugins.prettyerror = require('gulp-prettyerror');
 plugins.replace = require('gulp-replace');
 plugins.rollup = require('gulp-better-rollup');
-plugins.sass = require('gulp-sass');
+plugins.sass = require('gulp-sass')(require('sass'));
 plugins.sassLint = require('gulp-sass-lint');
 plugins.uglify = require('gulp-uglify');
 
@@ -97,7 +97,7 @@ const javascripts = () => {
 const sass = () => {
   return src(paths.src + '/stylesheets/main.scss')
     .pipe(plugins.prettyerror())
-    .pipe(plugins.sass({
+    .pipe(plugins.sass.sync({
       outputStyle: 'compressed',
       includePaths: [
         paths.govuk_frontend

--- a/package.json
+++ b/package.json
@@ -16,21 +16,22 @@
     "@rollup/plugin-commonjs": "11.0.1",
     "@rollup/plugin-node-resolve": "7.0.0",
     "govuk-frontend": "3.5.0",
-    "gulp": "4.0.0",
+    "gulp": "4.0.2",
     "gulp-add-src": "1.0.0",
     "gulp-better-rollup": "4.0.1",
     "gulp-concat": "2.6.1",
     "gulp-css-url-adjuster": "0.2.3",
     "gulp-jshint": "2.1.0",
-    "gulp-postcss": "8.0.0",
+    "gulp-postcss": "9.0.1",
     "gulp-prettyerror": "2.0.0",
-    "gulp-replace": "1.0.0",
-    "gulp-sass": "4.0.2",
+    "gulp-replace": "1.1.3",
+    "gulp-sass": "5.0.0",
     "gulp-sass-lint": "1.4.0",
     "gulp-uglify": "3.0.2",
     "jshint": "2.11.0",
     "jshint-stylish": "2.2.1",
     "oldie": "1.3.0",
-    "rollup": "1.20.0"
+    "rollup": "1.20.0",
+    "sass": "1.32.7"
   }
 }


### PR DESCRIPTION
Intended to deal with this security vulnerability:

https://github.blog/2021-09-08-github-security-update-vulnerabilities-tar-npmcli-arborist/

Bumping gulp-sass to version 5 removes its
dependency on the tar package mentioned in that
article.

Version 5 requires you to specify a compiler
directly in the gulpfile so that code is changed
in line with this guidance:

https://github.com/dlmanning/gulp-sass/tree/master#migrating-to-version-5

Note: node-sass is now deprecated so this also
changes the sass compiler gulp-sass uses to
dart-sass (aka 'sass'), the compiler now
recommended by the Sass project:

https://sass-lang.com/dart-sass

This also bumps gulp and all its plugins to the
latest version, for parity.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)
