### PR TITLE
Add security.txt page

### DIFF
--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -1,5 +1,5 @@
 import requests
-from flask import abort, current_app, render_template, request
+from flask import abort, current_app, redirect, render_template, request
 from notifications_python_client.errors import HTTPError
 
 from app import service_api_client
@@ -10,6 +10,14 @@ from app.utils import assess_contact_type
 @main.route('/_status')
 def status():
     return "ok", 200
+
+
+@main.route('/.well-known/security.txt', methods=['GET'])
+@main.route('/security.txt', methods=['GET'])
+def security_policy():
+    # See GDS Way security policy which this implements
+    # https://gds-way.cloudapps.digital/standards/vulnerability-disclosure.html#vulnerability-disclosure-and-security-txt
+    return redirect("https://vdp.cabinetoffice.gov.uk/.well-known/security.txt")
 
 
 @main.route('/d/<base64_uuid:service_id>/<base64_uuid:document_id>', methods=['GET'])

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -46,6 +46,19 @@ def test_status(client):
     assert response.get_data(as_text=True) == 'ok'
 
 
+@pytest.mark.parametrize('url', [
+    '/security.txt',
+    '/.well-known/security.txt',
+])
+def test_security_policy_redirects_to_policy(client, url):
+    response = client.get(
+        url
+    )
+
+    assert response.status_code == 302
+    assert response.location == "https://vdp.cabinetoffice.gov.uk/.well-known/security.txt"
+
+
 @pytest.mark.parametrize('view', ['main.landing', 'main.download_document'])
 def test_404_if_no_key_in_query_string(service_id, document_id, view, client):
     response = client.get(


### PR DESCRIPTION
This follows the guidance in
https://gds-way.cloudapps.digital/standards/vulnerability-disclosure.html#vulnerability-disclosure-and-security-txt

Note, I plan on just adding this for www.notifications.service.gov.uk
and documents.service.gov.uk.

I think we can get away with not adding it to the tech-docs or the
API but happy to be challenged on that

See https://github.com/alphagov/notifications-admin/pull/4088 for
equivalent on the admin app.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)
