### PR TITLE
Run npm commands in single build step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,16 +21,13 @@ run-flask:
 test:
 	flake8 .
 	isort --check-only ./app ./tests
-	npm test
+	source $(HOME)/.nvm/nvm.sh && npm test
 	pytest
 
 .PHONY: bootstrap
 bootstrap:
 	pip3 install -r requirements_for_test.txt
-	source $(HOME)/.nvm/nvm.sh && nvm install
-	npm ci
-	npm rebuild node-sass
-	npm run build
+	source $(HOME)/.nvm/nvm.sh && nvm install && npm ci && npm rebuild node-sass && npm run build
 
 .PHONY: freeze-requirements
 freeze-requirements: ## create static requirements.txt


### PR DESCRIPTION
Makefile steps run in isolated shells. The way that NVM adds npm to the PATH via sourced file means that it does not persist between make steps in a non-interactive shell.

This ensures that sourced environment vars provided by nvm are available to all commands in this step.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)
