### PR TITLE
Bump utils to 55.1.4 (no changes)

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -13,5 +13,5 @@ notifications-python-client==6.1.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@47.0.1#egg=notifications-utils==47.0.1
-git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==v0.5.1-alpha
+git+https://github.com/alphagov/notifications-utils.git@55.1.4
+git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,9 +5,7 @@
 #    pip-compile requirements.in
 #
 awscli==1.21.5
-    # via
-    #   awscli-cwlogs
-    #   notifications-utils
+    # via awscli-cwlogs
 awscli-cwlogs==1.4.6
     # via -r requirements.in
 bleach==4.1.0
@@ -22,7 +20,9 @@ botocore==1.22.5
 cachetools==4.2.4
     # via notifications-utils
 certifi==2021.10.8
-    # via requests
+    # via
+    #   pyproj
+    #   requests
 charset-normalizer==2.0.7
     # via requests
 click==8.0.3
@@ -75,7 +75,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==6.1.0
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@47.0.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@55.1.4
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils
@@ -90,6 +90,8 @@ pyjwt==2.3.0
 pyparsing==3.0.3
     # via packaging
 pypdf2==1.26.0
+    # via notifications-utils
+pyproj==3.3.0
     # via notifications-utils
 python-dateutil==2.8.2
     # via


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/181588331

This is also a good opportunity to remove the redundant egg spec in
the requirements, like we have in other repos.




---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)