### PR TITLE
Bump dependencies to their latest version

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 # Run `make freeze-requirements` to update requirements.txt
 # with package version changes made in requirements-app.txt
 
-Flask==1.1.2
+Flask==2.1.1
 
 gunicorn==20.1.0
 whitenoise==5.2.0  #manages static assets

--- a/requirements.in
+++ b/requirements.in
@@ -8,7 +8,7 @@ whitenoise==5.2.0  #manages static assets
 eventlet==0.30.2  # pyup: ignore # 0.31 breaks Gunicorn
 werkzeug==2.0.2
 
-notifications-python-client==6.1.0
+notifications-python-client==6.3.0
 
 # PaaS
 awscli-cwlogs>=1.4,<1.5

--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,7 @@ Flask==2.1.1
 gunicorn==20.1.0
 whitenoise==5.2.0  #manages static assets
 eventlet==0.30.2  # pyup: ignore # 0.31 breaks Gunicorn
-werkzeug==2.0.2
+werkzeug==2.1.1
 
 notifications-python-client==6.3.0
 

--- a/requirements.in
+++ b/requirements.in
@@ -4,7 +4,7 @@
 Flask==2.1.1
 
 gunicorn==20.1.0
-whitenoise==5.2.0  #manages static assets
+whitenoise==6.0.0  #manages static assets
 eventlet==0.30.2  # pyup: ignore # 0.31 breaks Gunicorn
 werkzeug==2.1.1
 

--- a/requirements.in
+++ b/requirements.in
@@ -13,5 +13,5 @@ notifications-python-client==6.3.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@55.1.4
+git+https://github.com/alphagov/notifications-utils.git@55.1.6
 govuk-frontend-jinja==2.0.0

--- a/requirements.in
+++ b/requirements.in
@@ -3,9 +3,9 @@
 
 Flask==2.1.1
 
-gunicorn==20.1.0
+# Should be pinned until a new gunicorn release greater than 20.1.0 comes out. (Due to eventlet v0.33 compatibility issues)
+git+https://github.com/benoitc/gunicorn.git@1299ea9e967a61ae2edebe191082fd169b864c64#egg=gunicorn[eventlet]==20.1.0
 whitenoise==6.0.0  #manages static assets
-eventlet==0.30.2  # pyup: ignore # 0.31 breaks Gunicorn
 werkzeug==2.1.1
 
 notifications-python-client==6.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -139,7 +139,7 @@ urllib3==1.26.7
     #   requests
 webencodings==0.5.1
     # via bleach
-werkzeug==2.0.2
+werkzeug==2.1.1
     # via
     #   -r requirements.in
     #   flask

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ docopt==0.6.2
     # via notifications-python-client
 docutils==0.15.2
     # via awscli
-eventlet==0.30.2  # pyup: ignore # 0.31 breaks Gunicorn
+eventlet==0.30.2
     # via -r requirements.in
 flask==1.1.2
     # via
@@ -73,7 +73,7 @@ markupsafe==2.0.1
     # via jinja2
 mistune==0.8.4
     # via notifications-utils
-notifications-python-client==6.1.0
+notifications-python-client==6.3.0
     # via -r requirements.in
 notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@55.1.4
     # via -r requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -143,7 +143,7 @@ werkzeug==2.1.1
     # via
     #   -r requirements.in
     #   flask
-whitenoise==5.2.0
+whitenoise==6.0.0
     # via -r requirements.in
 zipp==3.8.0
     # via importlib-metadata

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ docutils==0.15.2
     # via awscli
 eventlet==0.30.2
     # via -r requirements.in
-flask==1.1.2
+flask==2.1.1
     # via
     #   -r requirements.in
     #   flask-redis
@@ -56,6 +56,8 @@ gunicorn==20.1.0
     # via -r requirements.in
 idna==3.3
     # via requests
+importlib-metadata==4.11.3
+    # via flask
 itsdangerous==2.0.1
     # via
     #   flask
@@ -143,6 +145,8 @@ werkzeug==2.0.2
     #   flask
 whitenoise==5.2.0
     # via -r requirements.in
+zipp==3.8.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -75,7 +75,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==6.3.0
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@55.1.4
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@55.1.6
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils
@@ -89,7 +89,7 @@ pyjwt==2.3.0
     # via notifications-python-client
 pyparsing==3.0.3
     # via packaging
-pypdf2==1.26.0
+pypdf2==1.27.9
     # via notifications-utils
 pyproj==3.3.0
     # via notifications-utils

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,8 +35,8 @@ docopt==0.6.2
     # via notifications-python-client
 docutils==0.15.2
     # via awscli
-eventlet==0.30.2
-    # via -r requirements.in
+eventlet==0.33.0
+    # via gunicorn
 flask==2.1.1
     # via
     #   -r requirements.in
@@ -52,7 +52,7 @@ govuk-frontend-jinja==2.0.0
     # via -r requirements.in
 greenlet==1.1.2
     # via eventlet
-gunicorn==20.1.0
+gunicorn @ git+https://github.com/benoitc/gunicorn.git@1299ea9e967a61ae2edebe191082fd169b864c64
     # via -r requirements.in
 idna==3.3
     # via requests

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -3,13 +3,13 @@
 flake8==4.0.1
 isort==5.10.1
 
-pytest==6.2.5
-pytest-mock==3.6.1
+pytest==7.1.2
+pytest-mock==3.7.0
 pytest-cov==3.0.0
 pytest-env==0.6.2
 
 requests-mock==1.9.3
 
-jinja2-cli[yaml]==0.7.0
+jinja2-cli[yaml]==0.8.2
 
-beautifulsoup4==4.10.0
+beautifulsoup4==4.11.1

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -296,7 +296,6 @@ def test_landing_page_has_supplier_contact_info(
     document_has_metadata,
     client,
     mocker,
-    sample_service,
     contact_info,
     type,
     expected_result
@@ -316,6 +315,6 @@ def test_landing_page_has_supplier_contact_info(
     assert response.status_code == 200
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
     if type == 'number':
-        assert page.findAll(text=re.compile(expected_result))
+        assert page.find_all(string=re.compile(expected_result))
     else:
-        assert page.findAll(attrs={'href': expected_result})
+        assert page.find_all(attrs={'href': expected_result})


### PR DESCRIPTION
This bumps all dependencies to their latest version. There are some major version bumps here, but I can't find anything in the changelogs that would affect our code.

We had been blocked from upgrading Flask to version 2 because the version of `govuk-frontend-jinja` we were using was incompatible with it, but now that we have [changed the library we use](https://github.com/alphagov/document-download-frontend/pull/117), this is now possible.
 
---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)
