### PR TITLE
Add HTTP `Referrer-Policy` as `no-referrer`

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -81,6 +81,7 @@ def useful_headers_after_request(response):
     response.headers.add('X-Frame-Options', 'deny')
     response.headers.add('X-Content-Type-Options', 'nosniff')
     response.headers.add('X-XSS-Protection', '1; mode=block')
+    response.headers.add('Referrer-Policy', 'no-referrer')
     response.headers.add('Content-Security-Policy', (
         "default-src 'self' 'unsafe-inline';"
         "script-src 'self' *.google-analytics.com 'unsafe-inline' 'unsafe-eval' data:;"

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -245,7 +245,7 @@ def test_download_document_shows_contact_information(
 
 
 @pytest.mark.parametrize('view', ['main.landing', 'main.download_document'])
-def test_pages_are_not_indexed(
+def test_pages_contain_key_security_headers(
     view,
     service_id,
     document_id,
@@ -268,6 +268,7 @@ def test_pages_are_not_indexed(
 
     assert response.status_code == 200
     assert response.headers['X-Robots-Tag'] == 'noindex, nofollow'
+    assert response.headers['Referrer-Policy'] == 'no-referrer'
 
 
 @pytest.mark.parametrize('contact_info,type,expected_result', [


### PR DESCRIPTION
We have spotted links containing keys in the GOV.UK logs under the
`Referer` header. This is because we are not setting the
`Referrer-Policy`.

For additional context, see the equivalent change on doc download
API:
https://github.com/alphagov/document-download-api/pull/203



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)
