### PR TITLE
Add further protection for leaking of urls by `Referer` header

### DIFF
--- a/app/templates/document_download_template.html
+++ b/app/templates/document_download_template.html
@@ -23,6 +23,7 @@
     <script src="{{ asset_url('javascripts/html5shiv.min.js') }}"></script>
   <![endif]-->
   {% block meta %}
+  <meta name="referrer" content="never">
   {% endblock %}
 {% endblock %}
 

--- a/app/templates/views/download.html
+++ b/app/templates/views/download.html
@@ -14,13 +14,13 @@
   </p>
 
   <p class="govuk-body">
-    <a href="{{download_link}}" download class="govuk-link">Download this file to your device</a>
+    <a href="{{download_link}}" download class="govuk-link" rel="noreferrer">Download this file to your device</a>
   </p>
 
   <p class="govuk-body">
     If you have any questions,
     {% if contact_info_type == "link" %}
-      <a href="{{ service_contact_info }}" class="govuk-link"> contact {{ service_name }}</a>.
+      <a href="{{ service_contact_info }}" class="govuk-link" rel="noreferrer"> contact {{ service_name }}</a>.
     {% elif contact_info_type == "email" %}
       email <a href="mailto:{{ service_contact_info }}" class="govuk-link">{{service_contact_info}}</a>.
     {% else %}

--- a/app/templates/views/file_unavailable.html
+++ b/app/templates/views/file_unavailable.html
@@ -12,7 +12,7 @@
   <p class="govuk-body">
     If you have any questions,
     {% if contact_info_type == "link" %}
-      <a href="{{ service_contact_info }}" class="govuk-link"> contact {{ service_name }}</a>.
+      <a href="{{ service_contact_info }}" class="govuk-link" rel="noreferrer"> contact {{ service_name }}</a>.
     {% elif contact_info_type == "email" %}
       email <a href="mailto:{{ service_contact_info }}" class="govuk-link">{{service_contact_info}}</a>.
     {% else %}

--- a/app/templates/views/index.html
+++ b/app/templates/views/index.html
@@ -11,7 +11,7 @@
   <p class="govuk-body">
     If you’re not sure why you’ve been sent a file, or you have any questions,
     {% if contact_info_type == "link" %}
-      <a href="{{ service_contact_info }}" class="govuk-link"> contact {{ service_name }}</a>.
+      <a href="{{ service_contact_info }}" class="govuk-link" rel="noreferrer"> contact {{ service_name }}</a>.
     {% elif contact_info_type == "email" %}
       email <a href="mailto:{{ service_contact_info }}" class="govuk-link">{{service_contact_info}}</a>.
     {% else %}


### PR DESCRIPTION
In https://github.com/alphagov/document-download-frontend/pull/121
we added the `Referrer-Policy` header to help protect against
older browser versions from sending the url of the page using the
`Referer` header. However it turns out `Referrer-Policy` isn't
supported by all browsers, only roughly 95%:
https://caniuse.com/referrer-policy

There are some additional things we can do though to target
a slightly larger number of browsers.

1. `<meta name="referrer" content="never">`
This is the original draft spec for `Referrer-Policy` and is
supported by a few more browser versions than the current spec.
Read more about it in [1] on https://caniuse.com/referrer-policy.
This combined with the previous pull request is supported by
about 96% of browsers.

2. `rel="noreferrer"`.
Supported by about 96% of browsers: https://caniuse.com/rel-noreferrer
Can be applied on a link per link basis.
Has not been applied to the links to the national archives at the
bottom of the page because these are contained deep in the GOV.UK
Frontend and I don't think it is proportionate to duplicate all
of that code just to add the `rel="noreferrer"` to them.

Both of the above measures may give us an extra percent or so of
protection but we can't guarantee they will completely protect us
from users that support the `Referer` header but don't support any
of the above methods.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)
