### PR TITLE
Update top level dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "21.0.1",
     "@rollup/plugin-node-resolve": "13.1.3",
+    "better-npm-audit": "^3.7.3",
     "gulp": "4.0.2",
     "gulp-add-src": "1.0.0",
     "gulp-concat": "2.6.1",
@@ -33,8 +34,5 @@
     "rollup": "2.67.2",
     "rollup-plugin-terser": "7.0.2",
     "sass": "1.32.7"
-  },
-  "devDependencies": {
-    "better-npm-audit": "^3.7.3"
   }
 }

--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,7 @@ Flask==2.1.1
 # Should be pinned until a new gunicorn release greater than 20.1.0 comes out. (Due to eventlet v0.33 compatibility issues)
 git+https://github.com/benoitc/gunicorn.git@1299ea9e967a61ae2edebe191082fd169b864c64#egg=gunicorn[eventlet]==20.1.0
 whitenoise==6.2.0  #manages static assets
-werkzeug==2.1.1
+werkzeug==2.2.2
 
 notifications-python-client==6.3.0
 

--- a/requirements.in
+++ b/requirements.in
@@ -5,7 +5,7 @@ Flask==2.1.1
 
 # Should be pinned until a new gunicorn release greater than 20.1.0 comes out. (Due to eventlet v0.33 compatibility issues)
 git+https://github.com/benoitc/gunicorn.git@1299ea9e967a61ae2edebe191082fd169b864c64#egg=gunicorn[eventlet]==20.1.0
-whitenoise==6.0.0  #manages static assets
+whitenoise==6.2.0  #manages static assets
 werkzeug==2.1.1
 
 notifications-python-client==6.3.0

--- a/requirements.in
+++ b/requirements.in
@@ -13,5 +13,5 @@ notifications-python-client==6.3.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@55.1.6
+git+https://github.com/alphagov/notifications-utils.git@56.0.3
 govuk-frontend-jinja==2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -79,7 +79,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==6.3.0
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@55.1.6
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@56.0.3
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils
@@ -93,7 +93,7 @@ pyjwt==2.4.0
     # via notifications-python-client
 pyparsing==3.0.3
     # via packaging
-pypdf2==1.27.9
+pypdf2==2.10.3
     # via notifications-utils
 pyproj==3.3.0
     # via notifications-utils
@@ -135,6 +135,8 @@ smartypants==2.0.1
     # via notifications-utils
 statsd==3.3.0
     # via notifications-utils
+typing-extensions==4.3.0
+    # via pypdf2
 urllib3==1.26.7
     # via
     #   botocore

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,6 +56,8 @@ gunicorn @ git+https://github.com/benoitc/gunicorn.git@1299ea9e967a61ae2edebe191
     # via -r requirements.in
 idna==3.3
     # via requests
+importlib-metadata==4.12.0
+    # via flask
 itsdangerous==2.0.1
     # via
     #   flask
@@ -141,8 +143,10 @@ werkzeug==2.1.1
     # via
     #   -r requirements.in
     #   flask
-whitenoise==6.0.0
+whitenoise==6.2.0
     # via -r requirements.in
+zipp==3.8.1
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -71,8 +71,10 @@ jmespath==0.10.0
     # via
     #   boto3
     #   botocore
-markupsafe==2.0.1
-    # via jinja2
+markupsafe==2.1.1
+    # via
+    #   jinja2
+    #   werkzeug
 mistune==0.8.4
     # via notifications-utils
 notifications-python-client==6.3.0
@@ -139,7 +141,7 @@ urllib3==1.26.7
     #   requests
 webencodings==0.5.1
     # via bleach
-werkzeug==2.1.1
+werkzeug==2.2.2
     # via
     #   -r requirements.in
     #   flask

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,10 +1,10 @@
 -r requirements.txt
 
-flake8==4.0.1
+flake8==5.0.4
 isort==5.10.1
 
 pytest==7.1.2
-pytest-mock==3.7.0
+pytest-mock==3.8.2
 pytest-cov==3.0.0
 pytest-env==0.6.2
 


### PR DESCRIPTION
Updates the top level dependencies and fixes an error in the package.json file where the `devDependencies` section appeared twice.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
