### PR TITLE
Add a new page for confirming the email address

### DIFF
--- a/app/assets/javascripts/govuk-frontend-local.mjs
+++ b/app/assets/javascripts/govuk-frontend-local.mjs
@@ -8,6 +8,7 @@
 // For example, `export { Frontend }` will assign `Frontend` to `window.Frontend`
 import { nodeListForEach } from 'govuk-frontend/govuk/common'
 import Button from 'govuk-frontend/govuk/components/button/button'
+import ErrorSummary from 'govuk-frontend/govuk/components/error-summary/error-summary'
 import SkipLink from 'govuk-frontend/govuk/components/skip-link/skip-link'
 
 // Copy of the initAll function from https://github.com/alphagov/govuk-frontend/blob/v3.5.0/src/govuk/all.js
@@ -26,6 +27,10 @@ function initAll (options) {
     new Button(button).init()
   });
 
+  // Find first error summary module to enhance.
+  var $errorSummary = scope.querySelector('[data-module="govuk-error-summary"]')
+  new ErrorSummary($errorSummary).init()
+
   // There will only ever be one skip-link per page
   var skipLink = scope.querySelector('[data-module="govuk-skip-link"]')
 
@@ -34,6 +39,7 @@ function initAll (options) {
 
 var Frontend = {
   "Button": Button,
+  "ErrorSummary": ErrorSummary,
   "SkipLink": SkipLink,
   "initAll": initAll
 }

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -11,6 +11,7 @@ $govuk-assets-path: "/static/";
 @import "settings/all";
 @import "tools/all";
 @import "helpers/all";
+@import "utilities/all";
 
 @import "core/all";
 @import "objects/all";
@@ -19,4 +20,7 @@ $govuk-assets-path: "/static/";
 @import 'components/header/header';
 @import 'components/footer/footer';
 @import 'components/button/button';
+@import 'components/input/input';
+@import 'components/error-message/error-message';
+@import 'components/error-summary/error-summary';
 

--- a/app/config.py
+++ b/app/config.py
@@ -6,6 +6,7 @@ class Config(object):
     ADMIN_BASE_URL = os.environ.get('ADMIN_BASE_URL', 'http://localhost:6012')
     ADMIN_CLIENT_SECRET = os.environ.get('ADMIN_CLIENT_SECRET')
     ADMIN_CLIENT_USER_NAME = 'notify-admin'
+    SECRET_KEY = os.environ.get('SECRET_KEY')
 
     API_HOST_NAME = os.environ.get('API_HOST_NAME')
 
@@ -31,6 +32,7 @@ class Development(Config):
     DOCUMENT_DOWNLOAD_API_HOST_NAME = os.environ.get('DOCUMENT_DOWNLOAD_API_HOST_NAME', 'http://localhost:7000')
 
     ADMIN_CLIENT_SECRET = 'dev-notify-secret-key'
+    SECRET_KEY = 'dev-notify-secret-key'
 
     DEBUG = True
     NOTIFY_LOG_PATH = 'application.log'
@@ -40,7 +42,7 @@ class Test(Development):
     TESTING = True
 
     # used during tests as a domain name
-    SERVER_NAME = 'document-download-frontend'
+    SERVER_NAME = 'document-download-frontend.gov'
 
     API_HOST_NAME = 'http://test-notify-api'
     ADMIN_BASE_URL = 'http://test-notify-admin'

--- a/app/config.py
+++ b/app/config.py
@@ -40,6 +40,7 @@ class Development(Config):
 
 class Test(Development):
     TESTING = True
+    WTF_CSRF_ENABLED = False
 
     # used during tests as a domain name
     SERVER_NAME = 'document-download-frontend.gov'

--- a/app/forms.py
+++ b/app/forms.py
@@ -30,13 +30,13 @@ class EmailAddressField(StringField):
             error_message = None
 
         params = {
-            "id": "email-address-input",
-            "name": "email_address",
+            "id": self.id,
+            "name": self.name,
             "type": "email",
             "errorMessage": error_message,
             "label": {
                 "text": "Email address",
-                "for": "email-address-input",
+                "for": self.id,
             },
             "spellcheck": False,
             "autocomplete": "email",

--- a/app/forms.py
+++ b/app/forms.py
@@ -1,0 +1,53 @@
+from flask import Markup, render_template
+from flask_wtf import FlaskForm as Form
+from notifications_utils.formatters import strip_all_whitespace
+from notifications_utils.recipients import (
+    InvalidEmailError,
+    validate_email_address,
+)
+from wtforms import StringField, ValidationError
+from wtforms.validators import DataRequired
+
+
+class ValidEmail:
+    message = 'Not a valid email address'
+
+    def __call__(self, form, field):
+        if not field.data:
+            return
+
+        try:
+            validate_email_address(field.data)
+        except InvalidEmailError:
+            raise ValidationError(self.message)
+
+
+class EmailAddressField(StringField):
+    def widget(self, field, **kwargs):
+        if field.errors:
+            error_message = {"text": field.errors[0]}
+        else:
+            error_message = None
+
+        params = {
+            "id": "email-address-input",
+            "name": "email_address",
+            "type": "email",
+            "errorMessage": error_message,
+            "label": {
+                "text": "Email address",
+                "for": "email-address-input",
+            },
+            "spellcheck": False,
+            "autocomplete": "email",
+            "value": field.data
+        }
+        return Markup(render_template("components/govuk_input.html", params=params))
+
+
+class EmailAddressForm(Form):
+    email_address = EmailAddressField(
+        'Email address',
+        validators=[DataRequired('Enter your email address'), ValidEmail()],
+        filters=[strip_all_whitespace],
+    )

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -78,18 +78,13 @@ def confirm_email_address(service_id, document_id):
         )
 
     form = EmailAddressForm()
-    error_summary = None
 
     if form.validate_on_submit():
         return redirect(url_for('.download_document', service_id=service_id, document_id=document_id, key=key))
 
-    if form.email_address.errors:
-        error_summary = form.email_address.errors[0]
-
     return render_template(
         'views/confirm_email_address.html',
         form=form,
-        error_summary=error_summary,
         service_id=service_id,
         document_id=document_id,
         key=key,

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -1,8 +1,16 @@
 import requests
-from flask import abort, current_app, redirect, render_template, request
+from flask import (
+    abort,
+    current_app,
+    redirect,
+    render_template,
+    request,
+    url_for,
+)
 from notifications_python_client.errors import HTTPError
 
 from app import service_api_client
+from app.forms import EmailAddressForm
 from app.main import main
 from app.utils import assess_contact_type
 
@@ -26,10 +34,7 @@ def landing(service_id, document_id):
     if not key:
         abort(404)
 
-    try:
-        service = service_api_client.get_service(service_id)
-    except HTTPError as e:
-        abort(e.status_code)
+    service = _get_service_or_raise_error(service_id)
 
     service_contact_info = service['data']['contact_link']
     contact_info_type = assess_contact_type(service_contact_info)
@@ -53,16 +58,51 @@ def landing(service_id, document_id):
     )
 
 
+@main.route('/d/<base64_uuid:service_id>/<base64_uuid:document_id>/confirm-email-address', methods=['GET', 'POST'])
+def confirm_email_address(service_id, document_id):
+    key = request.args.get('key')
+    if not key:
+        abort(404)
+
+    service = _get_service_or_raise_error(service_id)
+
+    service_contact_info = service['data']['contact_link']
+    contact_info_type = assess_contact_type(service_contact_info)
+
+    if not _get_document_metadata(service_id, document_id, key):
+        return render_template(
+            'views/file_unavailable.html',
+            service_name=service['data']['name'],
+            service_contact_info=service_contact_info,
+            contact_info_type=contact_info_type,
+        )
+
+    form = EmailAddressForm()
+    error_summary = None
+
+    if form.validate_on_submit():
+        return redirect(url_for('.download_document', service_id=service_id, document_id=document_id, key=key))
+
+    if form.email_address.errors:
+        error_summary = form.email_address.errors[0]
+
+    return render_template(
+        'views/confirm_email_address.html',
+        form=form,
+        error_summary=error_summary,
+        service_id=service_id,
+        document_id=document_id,
+        key=key,
+    )
+
+
 @main.route('/d/<base64_uuid:service_id>/<base64_uuid:document_id>/download', methods=['GET'])
 def download_document(service_id, document_id):
     key = request.args.get('key', None)
     if not key:
         abort(404)
 
-    try:
-        service = service_api_client.get_service(service_id)
-    except HTTPError as e:
-        abort(e.status_code)
+    service = _get_service_or_raise_error(service_id)
 
     metadata = _get_document_metadata(service_id, document_id, key)
     service_contact_info = service['data']['contact_link']
@@ -83,6 +123,13 @@ def download_document(service_id, document_id):
         service_contact_info=service_contact_info,
         contact_info_type=contact_info_type,
     )
+
+
+def _get_service_or_raise_error(service_id):
+    try:
+        return service_api_client.get_service(service_id)
+    except HTTPError as e:
+        abort(e.status_code)
 
 
 def _get_document_metadata(service_id, document_id, key):

--- a/app/templates/components/govuk_input.html
+++ b/app/templates/components/govuk_input.html
@@ -1,0 +1,3 @@
+{%- from "govuk_frontend_jinja/components/input/macro.html" import govukInput -%}
+
+{{ govukInput(params) }}

--- a/app/templates/macros/error_summary.html
+++ b/app/templates/macros/error_summary.html
@@ -1,0 +1,19 @@
+{%- from "govuk_frontend_jinja/components/error-summary/macro.html" import govukErrorSummary -%}
+
+{% macro render_error_summary(form) %}
+  {% if form.errors %}
+    {% set errors = [] %}
+    {% for field_id in form.errors %}
+      {% if field_id %}
+        {% set _ = errors.append({"href": "#" + field_id, "text": form.errors[field_id][0]}) %}
+      {% else %}
+        {% set _ = errors.append({"text": form.errors[field_id][0]}) %}
+      {% endif %}
+    {% endfor %}
+
+    {{ govukErrorSummary({
+      "titleText": "There is a problem",
+      "errorList": errors
+    }) }}
+  {% endif %}
+{% endmacro %}

--- a/app/templates/views/confirm_email_address.html
+++ b/app/templates/views/confirm_email_address.html
@@ -1,26 +1,16 @@
 {% extends "document_download_template.html" %}
 {%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
-{%- from "govuk_frontend_jinja/components/error-summary/macro.html" import govukErrorSummary -%}
+{%- from "macros/error_summary.html" import render_error_summary -%}
 
 
 {% block per_page_title %}
-  {% if error_summary %}Error: {% endif %}Confirm your email address
+  {% if form.errors %}Error: {% endif %}Confirm your email address
 {% endblock %}
 
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      {% if error_summary %}
-        {{ govukErrorSummary({
-          "titleText": "There is a problem",
-          "errorList": [
-            {
-              "text": error_summary,
-              "href": "#email-address-input"
-            },
-          ]
-        }) }}
-      {% endif %}
+      {{ render_error_summary(form) }}
 
       <h1 class="govuk-heading-l">Confirm your email address</h1>
 

--- a/app/templates/views/confirm_email_address.html
+++ b/app/templates/views/confirm_email_address.html
@@ -1,0 +1,42 @@
+{% extends "document_download_template.html" %}
+{%- from "govuk_frontend_jinja/components/button/macro.html" import govukButton -%}
+{%- from "govuk_frontend_jinja/components/error-summary/macro.html" import govukErrorSummary -%}
+
+
+{% block per_page_title %}
+  {% if error_summary %}Error: {% endif %}Confirm your email address
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% if error_summary %}
+        {{ govukErrorSummary({
+          "titleText": "There is a problem",
+          "errorList": [
+            {
+              "text": error_summary,
+              "href": "#email-address-input"
+            },
+          ]
+        }) }}
+      {% endif %}
+
+      <h1 class="govuk-heading-l">Confirm your email address</h1>
+
+      <p class="govuk-body">
+        For security, we need to confirm the email address the file was sent to before you can download it.
+      </p>
+
+      <form method="post" novalidate>
+        {{ form.csrf_token }}
+        {{ form.email_address }}
+
+        {{ govukButton({
+          "text": "Continue",
+          "type": "submit"
+        }) }}
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -28,7 +28,7 @@ applications:
     ADMIN_BASE_URL: {{ ADMIN_BASE_URL }}
     ADMIN_CLIENT_SECRET: {{ ADMIN_CLIENT_SECRET }}
     API_HOST_NAME: {{ API_HOST_NAME }}
-
+    SECRET_KEY: '{{ SECRET_KEY }}'
 
     NOTIFY_APP_NAME: document-download-frontend
     FLASK_APP: application.py

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,3 +6,4 @@ env =
     FLASK_ENV=test
     ADMIN_CLIENT_SECRET=11111111-1111-1111-111111111111
     API_HOST_NAME=http://localhost:6014
+    SECRET_KEY=test-notify-secret-key

--- a/requirements.in
+++ b/requirements.in
@@ -2,6 +2,7 @@
 # with package version changes made in requirements-app.txt
 
 Flask==2.1.1
+Flask-WTF==1.0.1
 
 # Should be pinned until a new gunicorn release greater than 20.1.0 comes out. (Due to eventlet v0.33 compatibility issues)
 git+https://github.com/benoitc/gunicorn.git@1299ea9e967a61ae2edebe191082fd169b864c64#egg=gunicorn[eventlet]==20.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,9 +41,12 @@ flask==2.1.1
     # via
     #   -r requirements.in
     #   flask-redis
+    #   flask-wtf
     #   notifications-utils
 flask-redis==0.4.0
     # via notifications-utils
+flask-wtf==1.0.1
+    # via -r requirements.in
 geojson==2.5.0
     # via notifications-utils
 govuk-bank-holidays==0.10
@@ -61,6 +64,7 @@ importlib-metadata==4.12.0
 itsdangerous==2.0.1
     # via
     #   flask
+    #   flask-wtf
     #   notifications-utils
 jinja2==3.0.2
     # via
@@ -75,6 +79,7 @@ markupsafe==2.1.1
     # via
     #   jinja2
     #   werkzeug
+    #   wtforms
 mistune==0.8.4
     # via notifications-utils
 notifications-python-client==6.3.0
@@ -149,6 +154,8 @@ werkzeug==2.2.2
     #   flask
 whitenoise==6.2.0
     # via -r requirements.in
+wtforms==3.0.1
+    # via flask-wtf
 zipp==3.8.1
     # via importlib-metadata
 

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -9,36 +9,6 @@ from notifications_python_client.errors import HTTPError
 from tests import normalize_spaces
 
 
-@pytest.fixture
-def service_id():
-    return uuid4()
-
-
-@pytest.fixture
-def document_id():
-    return uuid4()
-
-
-@pytest.fixture
-def key():
-    return '1234'
-
-
-@pytest.fixture
-def document_has_metadata(service_id, document_id, key, rmock, client):
-    json_response = {"document": {"direct_file_url": "url"}}
-
-    rmock.get(
-        '{}/services/{}/documents/{}/check?key={}'.format(
-            current_app.config['DOCUMENT_DOWNLOAD_API_HOST_NAME'],
-            service_id,
-            document_id,
-            key
-        ),
-        json=json_response
-    )
-
-
 def test_status(client):
     response = client.get(url_for('main.status'))
     assert response.status_code == 200

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -285,7 +285,7 @@ def test_confirm_email_address_page_shows_an_error_if_the_email_address_is_inval
     assert normalize_spaces(page.select_one('.govuk-error-summary__list').text) == 'Not a valid email address'
 
     # Error above the form input
-    assert normalize_spaces(page.select_one('#email-address-input-error').text) == 'Error: Not a valid email address'
+    assert normalize_spaces(page.select_one('#email_address-error').text) == 'Error: Not a valid email address'
 
 
 def test_download_document_creates_link_to_actual_doc_from_api(

--- a/tests/app/test_errorhandlers.py
+++ b/tests/app/test_errorhandlers.py
@@ -1,4 +1,8 @@
 from bs4 import BeautifulSoup
+from flask import url_for
+from flask_wtf.csrf import CSRFError
+
+from tests import normalize_spaces
 
 
 def test_bad_url_returns_page_not_found(client):
@@ -6,3 +10,32 @@ def test_bad_url_returns_page_not_found(client):
     assert response.status_code == 404
     page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
     assert page.h1.string.strip() == 'Page not found'
+
+
+def test_csrf_error_returns_400_status_code_and_500_error_page(
+    service_id,
+    document_id,
+    key,
+    document_has_metadata,
+    client,
+    mocker,
+    sample_service,
+):
+    # we turn off CSRF handling for tests, so fake a CSRF response here.
+    csrf_err = CSRFError('400 Bad Request: The CSRF tokens do not match.')
+    mocker.patch('app.main.views.index.redirect', side_effect=csrf_err)
+    mocker.patch('app.service_api_client.get_service', return_value={'data': sample_service})
+
+    response = client.post(
+        url_for(
+            'main.confirm_email_address',
+            service_id=service_id,
+            document_id=document_id,
+            key=key,
+        ),
+        data={'email_address': 'me@example.com'}
+    )
+    assert response.status_code == 400
+
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    assert normalize_spaces(page.h1.text) == 'Sorry, there’s a problem with the service'

--- a/tests/app/test_forms.py
+++ b/tests/app/test_forms.py
@@ -1,0 +1,24 @@
+import pytest
+from werkzeug.datastructures import MultiDict
+
+from app.forms import EmailAddressForm
+
+
+def test_email_address_form_strips_whitespace(client):
+    form = EmailAddressForm(formdata=MultiDict([('email_address', '     me@example.com   ')]))
+
+    form.validate()
+
+    assert form.email_address.data == 'me@example.com'
+
+
+@pytest.mark.parametrize('email_address,error', [
+    ('invalid_email', 'Not a valid email address'),
+    ('', 'Enter your email address'),
+])
+def test_email_address_form_validates(client, email_address, error):
+    form = EmailAddressForm(formdata=MultiDict([('email_address', email_address)]))
+
+    form.validate()
+
+    assert form.email_address.errors == [error]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
+from uuid import uuid4
+
 import pytest
 import requests_mock
-from flask import Flask
+from flask import Flask, current_app
 
 from app import create_app
 
@@ -33,3 +35,33 @@ def sample_service():
 def rmock():
     with requests_mock.mock() as rmock:
         yield rmock
+
+
+@pytest.fixture
+def service_id():
+    return uuid4()
+
+
+@pytest.fixture
+def document_id():
+    return uuid4()
+
+
+@pytest.fixture
+def key():
+    return '1234'
+
+
+@pytest.fixture
+def document_has_metadata(service_id, document_id, key, rmock, client):
+    json_response = {"document": {"direct_file_url": "url"}}
+
+    rmock.get(
+        '{}/services/{}/documents/{}/check?key={}'.format(
+            current_app.config['DOCUMENT_DOWNLOAD_API_HOST_NAME'],
+            service_id,
+            document_id,
+            key
+        ),
+        json=json_response
+    )


### PR DESCRIPTION
This adds a new page for confirming the email address before you get redirected to the `/download` page. At the moment the new page is not linked to from anywhere and it only checks that an email address was entered in the form and that it is valid. 

See individual commits for details of the changes, but there are a couple of decisions made that can be changed easily: 
1. WTForms comes with CSRF protection built in, which means that the new endpoint added is protected. CSRF protection can be enabled globally - we do this in admin. I've not done that here since we don't have any AJAX requests or POST endpoints that don't use a form and are not planning on adding any. However, we could enable it globally anyway to avoid forgetting to add it in future https://flask-wtf.readthedocs.io/en/1.0.x/csrf/#csrf-protection
2. In the last commit I've copied what we do in admin by showing the `500` error page with a `400` status code if there is a CSRF error since that gives a more appropriate error message and logging the reason for the error.

[Pivotal story](https://www.pivotaltracker.com/story/show/182951632)

**Merge after**
- [x] https://github.com/alphagov/notifications-credentials/pull/293

**Screenshots**

<img width="450" alt="Screenshot 2022-08-31 at 19 52 06" src="https://user-images.githubusercontent.com/12881990/187771805-8ef802a9-5ef4-411f-9ee8-336982edac84.png">

<img width="450" alt="Screenshot 2022-09-01 at 12 20 57" src="https://user-images.githubusercontent.com/12881990/187902256-6999d156-d528-4e81-b0e8-74bb5aac501e.png">

<img width="450" alt="Screenshot 2022-08-31 at 19 52 30" src="https://user-images.githubusercontent.com/12881990/187771979-6e6a7775-0630-4adf-9d12-f085e0386d92.png">

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
