### PR TITLE
Redirect to confirm email address page

### DIFF
--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -38,14 +38,21 @@ def landing(service_id, document_id):
 
     service_contact_info = service['data']['contact_link']
     contact_info_type = assess_contact_type(service_contact_info)
+    metadata = _get_document_metadata(service_id, document_id, key)
 
-    if not _get_document_metadata(service_id, document_id, key):
+    if not metadata:
         return render_template(
             'views/file_unavailable.html',
             service_name=service['data']['name'],
             service_contact_info=service_contact_info,
             contact_info_type=contact_info_type,
         )
+
+    if metadata['verify_email'] is True:
+        continue_url = url_for('main.confirm_email_address', service_id=service_id, document_id=document_id, key=key)
+
+    else:
+        continue_url = url_for('main.download_document', service_id=service_id, document_id=document_id, key=key)
 
     return render_template(
         'views/index.html',
@@ -54,7 +61,8 @@ def landing(service_id, document_id):
         service_contact_info=service_contact_info,
         contact_info_type=contact_info_type,
         document_id=document_id,
-        key=key
+        key=key,
+        continue_url=continue_url,
     )
 
 

--- a/app/templates/views/index.html
+++ b/app/templates/views/index.html
@@ -20,7 +20,7 @@
   </p>
   <p class="govuk-body">
     {{ govukButton({
-      "href": url_for('main.download_document', service_id=service_id, document_id=document_id, key=key),
+      "href": continue_url,
       "text": "Continue",
       "element": "a",
     }) }}

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -196,6 +196,38 @@ def test_landing_page_creates_link_for_document(
     )
 
 
+def test_landing_page_creates_link_to_confirm_email_address(
+    service_id,
+    document_id,
+    key,
+    document_has_metadata_requires_verification,
+    client,
+    mocker,
+    sample_service
+):
+    mocker.patch('app.service_api_client.get_service', return_value={'data': sample_service})
+
+    response = client.get(
+        url_for(
+            'main.landing',
+            service_id=service_id,
+            document_id=document_id,
+            key=key,
+        )
+    )
+
+    assert response.status_code == 200
+    page = BeautifulSoup(response.data.decode('utf-8'), 'html.parser')
+    assert normalize_spaces(page.title.text) == 'You have a file to download – GOV.UK'
+    assert normalize_spaces(page.h1.text) == 'You have a file to download'
+    assert page.find('a', string=re.compile("Continue"))['href'] == url_for(
+        'main.confirm_email_address',
+        service_id=service_id,
+        document_id=document_id,
+        key='1234'
+    )
+
+
 def test_confirm_email_address_page_show_email_address_form(
     service_id,
     document_id,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,7 +54,22 @@ def key():
 
 @pytest.fixture
 def document_has_metadata(service_id, document_id, key, rmock, client):
-    json_response = {"document": {"direct_file_url": "url"}}
+    json_response = {"document": {"direct_file_url": "url", "verify_email": False}}
+
+    rmock.get(
+        '{}/services/{}/documents/{}/check?key={}'.format(
+            current_app.config['DOCUMENT_DOWNLOAD_API_HOST_NAME'],
+            service_id,
+            document_id,
+            key
+        ),
+        json=json_response
+    )
+
+
+@pytest.fixture
+def document_has_metadata_requires_verification(service_id, document_id, key, rmock, client):
+    json_response = {"document": {"direct_file_url": "url", "verify_email": True}}
 
     rmock.get(
         '{}/services/{}/documents/{}/check?key={}'.format(


### PR DESCRIPTION
When the user arrives at the document download frontend on the landing
page, let's check the document metadata to see whether email
confirmation is required. If it is, we need to direct them to the form
rather than directly to the download link.

Need to merge https://github.com/alphagov/document-download-api/pull/216 first.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
