### PR TITLE
Verify email address against document

### DIFF
--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -13,3 +13,4 @@ requests-mock==1.9.3
 jinja2-cli[yaml]==0.8.2
 
 beautifulsoup4==4.11.1
+freezegun==1.2.2

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -169,7 +169,7 @@ def test_landing_page_creates_link_for_document(
     service_id,
     document_id,
     key,
-    document_has_metadata,
+    document_has_metadata_no_verification,
     client,
     mocker,
     sample_service
@@ -261,7 +261,7 @@ def test_confirm_email_address_page_redirects_to_download_page_if_verification_n
     service_id,
     document_id,
     key,
-    document_has_metadata,
+    document_has_metadata_no_verification,
     client,
     mocker,
     sample_service,
@@ -409,7 +409,7 @@ def test_confirm_email_address_page_redirects_and_sets_cookie_on_success(
     assert any(
         header == (
             'Set-Cookie',
-            'document_access_signed_data=blah; Expires=Sun, 02 Jan 2000 12:34:56 GMT; HttpOnly; Path=/my/file/path'
+            'document_access_signed_data=blah; HttpOnly; Path=/my/file/path'
         )
         for header in response.headers
     )
@@ -419,7 +419,7 @@ def test_download_document_creates_link_to_actual_doc_from_api(
     service_id,
     document_id,
     key,
-    document_has_metadata,
+    document_has_metadata_no_verification,
     client,
     mocker,
     sample_service
@@ -446,7 +446,7 @@ def test_download_document_shows_contact_information(
     service_id,
     document_id,
     key,
-    document_has_metadata,
+    document_has_metadata_no_verification,
     client,
     mocker,
     sample_service
@@ -507,7 +507,7 @@ def test_landing_page_has_supplier_contact_info(
     service_id,
     document_id,
     key,
-    document_has_metadata,
+    document_has_metadata_no_verification,
     client,
     mocker,
     contact_info,
@@ -538,7 +538,7 @@ def test_footer_doesnt_link_to_national_archives(
     service_id,
     document_id,
     key,
-    document_has_metadata,
+    document_has_metadata_no_verification,
     client,
     mocker,
 ):

--- a/tests/app/test_errorhandlers.py
+++ b/tests/app/test_errorhandlers.py
@@ -16,7 +16,7 @@ def test_csrf_error_returns_400_status_code_and_500_error_page(
     service_id,
     document_id,
     key,
-    document_has_metadata,
+    document_has_metadata_no_verification,
     client,
     mocker,
     sample_service,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,7 +53,7 @@ def key():
 
 
 @pytest.fixture
-def document_has_metadata(service_id, document_id, key, rmock, client):
+def document_has_metadata_no_verification(service_id, document_id, key, rmock, client):
     json_response = {"document": {"direct_file_url": "url", "verify_email": False}}
 
     rmock.get(


### PR DESCRIPTION
When a user submits their email address to the validation form, let's now actually start checking against the API to see if the email address matches that we've stored on the document (thereby actually enforcing the security check).

A few decisions made here:
1) If the user gets to the 'confirm email address' page for a document that doesn't actually require verification, let's just redirect them automatically to the download document page.
2) When successfully authenticated, we set an auth cookie containing data signed by the API on the user's client. This cookie lasts 24 hours
- so after confirming their email address, they have 24 hours to access and download the file before they need to authenticate again.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
