### PR TITLE
Add logging to understand error better

### DIFF
--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -48,7 +48,12 @@ def landing(service_id, document_id):
             contact_info_type=contact_info_type,
         )
 
-    if metadata['verify_email'] is True:
+    if 'verify_email' not in metadata:
+        current_app.logger.info(
+            f'Metadata for {service_id}/{document_id} does not contain `verify_email` key: {metadata}'
+        )
+
+    if metadata.get('verify_email', False) is True:
         continue_url = url_for('main.confirm_email_address', service_id=service_id, document_id=document_id, key=key)
 
     else:


### PR DESCRIPTION
In the latest release, a small percentage of requests raised KeyErrors on missing `verify_email` keys. We believe this key should always be present.

This patch does a soft retrieve of `verify_email` so that it won't error if the key is missing, and logs the document metadata if it's missing so that we can get some more information on what might be happening.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
