### PR TITLE
Pull secret key from _frontend specific cred

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -28,7 +28,7 @@ applications:
     ADMIN_BASE_URL: {{ ADMIN_BASE_URL }}
     ADMIN_CLIENT_SECRET: {{ ADMIN_CLIENT_SECRET }}
     API_HOST_NAME: {{ API_HOST_NAME }}
-    SECRET_KEY: '{{ SECRET_KEY }}'
+    SECRET_KEY: '{{ SECRET_KEY_FRONTEND }}'
 
     NOTIFY_APP_NAME: document-download-frontend
     FLASK_APP: application.py


### PR DESCRIPTION
We've updated the credentials to make it explicit which secret is for which document download app (api vs frontend).



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
