### PR TITLE
Content tweaks

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -12,6 +12,7 @@ $govuk-assets-path: "/static/";
 @import "tools/all";
 @import "helpers/all";
 @import "utilities/all";
+@import "overrides/spacing";
 
 @import "core/all";
 @import "objects/all";

--- a/app/templates/views/file_unavailable.html
+++ b/app/templates/views/file_unavailable.html
@@ -6,7 +6,7 @@
 
 {% block main_content %}
   <p class="govuk-body">
-    The file you are looking for has expired or been deleted.
+    The file {{ service_name }} sent you has expired or been deleted.
   </p>
 
   <p class="govuk-body">

--- a/app/templates/views/index.html
+++ b/app/templates/views/index.html
@@ -8,6 +8,13 @@
 
 {% block main_content %}
   <p class="govuk-body">{{ service_name or '[SERVICE_NAME]'}} sent you a file to download.</p>
+  <p class="govuk-body govuk-!-margin-bottom-0">
+    {{ govukButton({
+      "href": continue_url,
+      "text": "Continue",
+      "element": "a",
+    }) }}
+  </p>
   <p class="govuk-body">
     If you’re not sure why you’ve been sent a file, or you have any questions,
     {% if contact_info_type == "link" %}
@@ -17,12 +24,5 @@
     {% else %}
       call {{ service_contact_info }}.
     {% endif %}
-  </p>
-  <p class="govuk-body">
-    {{ govukButton({
-      "href": continue_url,
-      "text": "Continue",
-      "element": "a",
-    }) }}
   </p>
 {% endblock %}


### PR DESCRIPTION
This PR addresses the two easy fixes in https://www.pivotaltracker.com/story/show/183012123

## Moves the continue button up on the landing page

#### Before
<img width="1730" alt="image" src="https://user-images.githubusercontent.com/7228605/190200047-13306203-d640-4b62-853a-73e13a34b968.png">

#### After

<img width="1729" alt="image" src="https://user-images.githubusercontent.com/7228605/190199944-0a3c78ad-8cb8-4728-a546-2e7d353b3603.png">



## Adds the service name to the unavailable page

#### Before
![image](https://user-images.githubusercontent.com/7228605/190200345-7ef7ab49-c388-48b3-9f2f-255c32858075.png)


#### After
<img width="1730" alt="image" src="https://user-images.githubusercontent.com/7228605/190200434-a22c3753-4801-4a33-b3a9-ba48d286f951.png">

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
