### PR TITLE
Show pretty file size before downloading file

### DIFF
--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -16,7 +16,7 @@ from notifications_python_client.errors import HTTPError
 from app import service_api_client
 from app.forms import EmailAddressForm
 from app.main import main
-from app.utils import assess_contact_type
+from app.utils import assess_contact_type, bytes_to_pretty_file_size
 
 
 @main.route('/_status')
@@ -153,6 +153,7 @@ def download_document(service_id, document_id):
     return render_template(
         'views/download.html',
         download_link=metadata['direct_file_url'],
+        file_size=bytes_to_pretty_file_size(metadata['size_in_bytes']),
         service_name=service['data']['name'],
         service_contact_info=service_contact_info,
         contact_info_type=contact_info_type,

--- a/app/templates/views/download.html
+++ b/app/templates/views/download.html
@@ -14,7 +14,7 @@
   </p>
 
   <p class="govuk-body">
-    <a href="{{download_link}}" download class="govuk-link" rel="noreferrer">Download this file to your device</a>
+    <a href="{{download_link}}" download class="govuk-link" rel="noreferrer">Download this file ({{ file_size }}) to your device</a>
   </p>
 
   <p class="govuk-body">

--- a/app/utils.py
+++ b/app/utils.py
@@ -24,3 +24,18 @@ def assess_contact_type(service_contact_info):
         return "link"
     else:
         return "other"
+
+
+def bytes_to_pretty_file_size(bytes):
+    if bytes < 1024 / 20:
+        # File less than 0.05KB (one twentieth of a KB) don't round to 0.1KB at 1 d.p.
+        # We will force them up to 0.1KB ourselves as we don't want to show users 0.0KB or bytes
+        return "0.1KB"
+    elif bytes < (1024**2) / 20:
+        # File less than 0.05MB to be represented in KB
+        # Anything bigger will round at 1dp to at least 0.1MB
+        kb_to_1dp = round(bytes / 1024, 1)
+        return str(kb_to_1dp).rstrip(".0") + "KB"
+    else:
+        mb_to_1dp = round(bytes / (1024**2), 1)
+        return str(mb_to_1dp).rstrip(".0") + "MB"

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -440,6 +440,7 @@ def test_download_document_creates_link_to_actual_doc_from_api(
     assert normalize_spaces(page.title.text) == 'Download your file – GOV.UK'
     assert normalize_spaces(page.h1.text) == 'Download your file'
     assert page.select('main a')[0]['href'] == 'url'
+    assert page.select('main a')[0].text == 'Download this file (0.7MB) to your device'
 
 
 def test_download_document_shows_contact_information(

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -1,6 +1,10 @@
 import pytest
 
-from app.utils import assess_contact_type, get_cdn_domain
+from app.utils import (
+    assess_contact_type,
+    bytes_to_pretty_file_size,
+    get_cdn_domain,
+)
 
 
 def test_get_cdn_domain_on_localhost(client, mocker):
@@ -30,3 +34,28 @@ def test_get_cdn_domain_on_non_localhost(client, mocker):
 )
 def test_assess_contact_type_recognises_email_phone_and_link(contact_info, expected_result):
     assert assess_contact_type(contact_info) == expected_result
+
+
+@pytest.mark.parametrize(
+    "bytes,expected_result",
+    [
+        (0, "0.1KB"),
+        (1, "0.1KB"),
+        (51, "0.1KB"),  # 0.0498046875KB which rounds to 0.0KB but we force it to 0.1KB
+        (52, "0.1KB"),  # 0.05078125KB so rounds to 0.1KB
+        (153, "0.1KB"),  # 0.1494140625KB so rounds to 0.1KB
+        (154, "0.2KB"),  # 0.150390625KB so rounds to 0.2KB
+        (1023, "1KB"),
+        (1024, "1KB"),  # exactly 1KB
+        (1025, "1KB"),
+        (2048, "2KB"),  # exactly 2KB
+        (52428, "51.2KB"),  # 0.049999MB so stays as KB
+        (52429, "0.1MB"),  # 0.0500001MB so rounds to 0.1MB
+        (1048576, "1MB"),  # exactly 1MB
+        (2023751, "1.9MB"),
+        (2097151, "2MB"),
+        (2097152, "2MB"),  # exactly 2MB
+    ]
+)
+def test_bytes_to_pretty_file_size(bytes, expected_result):
+    assert bytes_to_pretty_file_size(bytes) == expected_result

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,7 +54,7 @@ def key():
 
 @pytest.fixture
 def document_has_metadata_no_verification(service_id, document_id, key, rmock, client):
-    json_response = {"document": {"direct_file_url": "url", "verify_email": False}}
+    json_response = {"document": {"direct_file_url": "url", "verify_email": False, "size_in_bytes": 712099}}
 
     rmock.get(
         '{}/services/{}/documents/{}/check?key={}'.format(
@@ -69,7 +69,7 @@ def document_has_metadata_no_verification(service_id, document_id, key, rmock, c
 
 @pytest.fixture
 def document_has_metadata_requires_verification(service_id, document_id, key, rmock, client):
-    json_response = {"document": {"direct_file_url": "url", "verify_email": True}}
+    json_response = {"document": {"direct_file_url": "url", "verify_email": True, "size_in_bytes": 1923823}}
 
     rmock.get(
         '{}/services/{}/documents/{}/check?key={}'.format(


### PR DESCRIPTION
This is part of the https://www.pivotaltracker.com/story/show/183012123 pivotal story. 

The suggested content we aim for is `Download this ((filetype)) (((file size))) to your device`.

In the aim of doing things in small steps, I've only added the file size for the moment. The filetype can come in a subsequent PR. Given this, does it make sense for the filesize to go where I've added it or should it instead go on the end. That is where I'd personally expect it to so it would look like `Download this file to your device (1.4MB)`.

Thoughts @saimaghafoor please?

<img width="1730" alt="image" src="https://user-images.githubusercontent.com/7228605/190217739-cbd500c6-b358-49e6-94a2-9af64247e2ef.png">

<img width="1743" alt="image" src="https://user-images.githubusercontent.com/7228605/190443782-b3d8ce25-cbb1-4da2-84d2-36f6cea5e761.png">

<img width="1743" alt="image" src="https://user-images.githubusercontent.com/7228605/190443838-274291fc-ddd3-4775-9f65-07b0b0b26dd2.png">



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
