### PR TITLE
Rename `verify_email` to `confirm_email`

### DIFF
--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -53,12 +53,12 @@ def landing(service_id, document_id):
             contact_info_type=contact_info_type,
         )
 
-    if 'verify_email' not in metadata:
+    if 'confirm_email' not in metadata:
         current_app.logger.info(
-            f'Metadata for {service_id}/{document_id} does not contain `verify_email` key: {metadata}'
+            f'Metadata for {service_id}/{document_id} does not contain `confirm_email` key: {metadata}'
         )
 
-    if metadata.get('verify_email', False) is True:
+    if metadata.get('confirm_email', False) is True:
         continue_url = url_for('main.confirm_email_address', service_id=service_id, document_id=document_id, key=key)
 
     else:
@@ -97,7 +97,7 @@ def confirm_email_address(service_id, document_id):
             contact_info_type=contact_info_type,
         )
 
-    if metadata['verify_email'] is False:
+    if metadata['confirm_email'] is False:
         return redirect(url_for('.download_document', service_id=service_id, document_id=document_id, key=key))
 
     form = EmailAddressForm()

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -170,7 +170,7 @@ def test_landing_page_creates_link_for_document(
     service_id,
     document_id,
     key,
-    document_has_metadata_no_verification,
+    document_has_metadata_no_confirmation,
     client,
     mocker,
     sample_service
@@ -202,7 +202,7 @@ def test_landing_page_creates_link_to_confirm_email_address(
     service_id,
     document_id,
     key,
-    document_has_metadata_requires_verification,
+    document_has_metadata_requires_confirmation,
     client,
     mocker,
     sample_service
@@ -234,7 +234,7 @@ def test_confirm_email_address_page_show_email_address_form(
     service_id,
     document_id,
     key,
-    document_has_metadata_requires_verification,
+    document_has_metadata_requires_confirmation,
     client,
     mocker,
     sample_service,
@@ -258,11 +258,11 @@ def test_confirm_email_address_page_show_email_address_form(
     assert not page.select('.govuk-error-summary')
 
 
-def test_confirm_email_address_page_redirects_to_download_page_if_verification_not_required(
+def test_confirm_email_address_page_redirects_to_download_page_if_confirmation_not_required(
     service_id,
     document_id,
     key,
-    document_has_metadata_no_verification,
+    document_has_metadata_no_confirmation,
     client,
     mocker,
     sample_service,
@@ -290,7 +290,7 @@ def test_confirm_email_address_page_shows_an_error_if_the_email_address_is_inval
     service_id,
     document_id,
     key,
-    document_has_metadata_requires_verification,
+    document_has_metadata_requires_confirmation,
     client,
     mocker,
     sample_service,
@@ -324,7 +324,7 @@ def test_confirm_email_address_page_shows_error_if_wrong_email_address(
     service_id,
     document_id,
     key,
-    document_has_metadata_requires_verification,
+    document_has_metadata_requires_confirmation,
     client,
     mocker,
     sample_service,
@@ -372,7 +372,7 @@ def test_confirm_email_address_page_shows_429_error_page_if_auth_rate_limited(
     service_id,
     document_id,
     key,
-    document_has_metadata_requires_verification,
+    document_has_metadata_requires_confirmation,
     client,
     mocker,
     sample_service,
@@ -418,7 +418,7 @@ def test_confirm_email_address_page_redirects_and_sets_cookie_on_success(
     service_id,
     document_id,
     key,
-    document_has_metadata_requires_verification,
+    document_has_metadata_requires_confirmation,
     client,
     mocker,
     sample_service,
@@ -465,7 +465,7 @@ def test_download_document_creates_link_to_actual_doc_from_api(
     service_id,
     document_id,
     key,
-    document_has_metadata_no_verification,
+    document_has_metadata_no_confirmation,
     client,
     mocker,
     sample_service
@@ -493,7 +493,7 @@ def test_download_document_shows_contact_information(
     service_id,
     document_id,
     key,
-    document_has_metadata_no_verification,
+    document_has_metadata_no_confirmation,
     client,
     mocker,
     sample_service
@@ -523,7 +523,7 @@ def test_pages_contain_key_security_headers(
     service_id,
     document_id,
     key,
-    document_has_metadata_requires_verification,
+    document_has_metadata_requires_confirmation,
     client,
     mocker,
     sample_service
@@ -554,7 +554,7 @@ def test_landing_page_has_supplier_contact_info(
     service_id,
     document_id,
     key,
-    document_has_metadata_no_verification,
+    document_has_metadata_no_confirmation,
     client,
     mocker,
     contact_info,
@@ -585,7 +585,7 @@ def test_footer_doesnt_link_to_national_archives(
     service_id,
     document_id,
     key,
-    document_has_metadata_no_verification,
+    document_has_metadata_no_confirmation,
     client,
     mocker,
 ):

--- a/tests/app/test_errorhandlers.py
+++ b/tests/app/test_errorhandlers.py
@@ -16,7 +16,7 @@ def test_csrf_error_returns_400_status_code_and_500_error_page(
     service_id,
     document_id,
     key,
-    document_has_metadata_no_verification,
+    document_has_metadata_no_confirmation,
     client,
     mocker,
     sample_service,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,8 +53,8 @@ def key():
 
 
 @pytest.fixture
-def document_has_metadata_no_verification(service_id, document_id, key, rmock, client):
-    json_response = {"document": {"direct_file_url": "url", "verify_email": False, "size_in_bytes": 712099}}
+def document_has_metadata_no_confirmation(service_id, document_id, key, rmock, client):
+    json_response = {"document": {"direct_file_url": "url", "confirm_email": False, "size_in_bytes": 712099}}
 
     rmock.get(
         '{}/services/{}/documents/{}/check?key={}'.format(
@@ -68,8 +68,8 @@ def document_has_metadata_no_verification(service_id, document_id, key, rmock, c
 
 
 @pytest.fixture
-def document_has_metadata_requires_verification(service_id, document_id, key, rmock, client):
-    json_response = {"document": {"direct_file_url": "url", "verify_email": True, "size_in_bytes": 1923823}}
+def document_has_metadata_requires_confirmation(service_id, document_id, key, rmock, client):
+    json_response = {"document": {"direct_file_url": "url", "confirm_email": True, "size_in_bytes": 1923823}}
 
     rmock.get(
         '{}/services/{}/documents/{}/check?key={}'.format(


### PR DESCRIPTION
We prefer `confirm` in documentation and guidance, so let's rename it in the code to keep things more consistent.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
