### PR TITLE
Show pretty file type on the download link for a file

### DIFF
--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -12,6 +12,17 @@ from app.forms import EmailAddressForm
 from app.main import main
 from app.utils import assess_contact_type, bytes_to_pretty_file_size
 
+FILE_EXTENSION_TO_PRETTY_FILE_TYPE = {
+    "csv": "CSV file",
+    "doc": "Microsoft Word document",
+    "docx": "Microsoft Word document",
+    "odt": "text file",
+    "pdf": "PDF",
+    "rtf": "text file",
+    "txt": "text file",
+    "xlsx": "Microsoft Excel spreadsheet",
+}
+
 
 @main.route("/_status")
 def status():
@@ -161,6 +172,7 @@ def download_document(service_id, document_id):
         "views/download.html",
         download_link=metadata["direct_file_url"],
         file_size=bytes_to_pretty_file_size(metadata["size_in_bytes"]),
+        file_type=FILE_EXTENSION_TO_PRETTY_FILE_TYPE[metadata["file_extension"]],
         service_name=service["data"]["name"],
         service_contact_info=service_contact_info,
         contact_info_type=contact_info_type,

--- a/app/templates/views/download.html
+++ b/app/templates/views/download.html
@@ -14,7 +14,7 @@
   </p>
 
   <p class="govuk-body">
-    <a href="{{download_link}}" download class="govuk-link" rel="noreferrer">Download this file ({{ file_size }}) to your device</a>
+    <a href="{{download_link}}" download class="govuk-link" rel="noreferrer">Download this {{ file_type }} ({{ file_size }}) to your device</a>
   </p>
 
   <p class="govuk-body">

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,7 +54,9 @@ def key():
 
 @pytest.fixture
 def document_has_metadata_no_confirmation(service_id, document_id, key, rmock, client):
-    json_response = {"document": {"direct_file_url": "url", "confirm_email": False, "size_in_bytes": 712099}}
+    json_response = {
+        "document": {"direct_file_url": "url", "confirm_email": False, "size_in_bytes": 712099, "file_extension": "txt"}
+    }
 
     rmock.get(
         "{}/services/{}/documents/{}/check?key={}".format(
@@ -66,7 +68,9 @@ def document_has_metadata_no_confirmation(service_id, document_id, key, rmock, c
 
 @pytest.fixture
 def document_has_metadata_requires_confirmation(service_id, document_id, key, rmock, client):
-    json_response = {"document": {"direct_file_url": "url", "confirm_email": True, "size_in_bytes": 1923823}}
+    json_response = {
+        "document": {"direct_file_url": "url", "confirm_email": True, "size_in_bytes": 1923823, "file_extension": "pdf"}
+    }
 
     rmock.get(
         "{}/services/{}/documents/{}/check?key={}".format(


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/183012123

<img width="714" alt="image" src="https://user-images.githubusercontent.com/7228605/192334552-9c9653e1-fb1f-41da-b773-fcdd58028397.png">

<img width="689" alt="image" src="https://user-images.githubusercontent.com/7228605/192334684-8d282333-61ce-4fb7-b3b8-224d74cad41d.png">

<img width="676" alt="image" src="https://user-images.githubusercontent.com/7228605/192335308-3293084c-a397-46b6-85ef-533e72ebc990.png">


Karls initial suggestion was that we should handle any unexpected file extensions that aren't covered by our dictionary by referring to them as their file extension. However I think I'd prefer that we fail hard and get an error to indicate that we have missed something rather than failing soft and not knowing that we've missed something. When we add support for other filetypes, we will need to remember to change the frontend too.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
