### PR TITLE
Check for file expiry in all views

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -1,6 +1,8 @@
 import re
+from datetime import date
 from urllib.parse import urlparse
 
+from dateutil import parser
 from flask import current_app
 from notifications_utils.recipients import EMAIL_REGEX_PATTERN
 
@@ -39,3 +41,14 @@ def bytes_to_pretty_file_size(bytes):
     else:
         mb_to_1dp = round(bytes / (1024**2), 1)
         return str(mb_to_1dp).rstrip(".0") + "MB"
+
+
+def document_has_expired(available_until):
+    file_expiry_date = parser.parse(available_until).date()
+
+    # if expiry date passed, even if file is still available, we do not return it to respect data retention period
+    # set by the service
+    if file_expiry_date < date.today():
+        return True
+
+    return False

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -506,8 +506,9 @@ def test_download_document_shows_expiry_date(
     assert f"This file is available until {expected_content}." in content_about_expiry_date.text
 
 
+@pytest.mark.parametrize("view", ("main.landing", "main.confirm_email_address", "main.download_document"))
 def test_download_document_returns_404_if_file_past_expiry_date(
-    service_id, document_id, key, client, mocker, sample_service
+    service_id, document_id, key, client, mocker, sample_service, view
 ):
     mocker.patch("app.service_api_client.get_service", return_value={"data": sample_service})
 
@@ -520,7 +521,7 @@ def test_download_document_returns_404_if_file_past_expiry_date(
     }
     mocker.patch("app.main.views.index._get_document_metadata", return_value=mocked_metadata)
 
-    response = client.get(url_for("main.download_document", service_id=service_id, document_id=document_id, key=key))
+    response = client.get(url_for(view, service_id=service_id, document_id=document_id, key=key))
 
     assert response.status_code == 404
 


### PR DESCRIPTION
We should 404 on all pages when trying to access a document which has expired, not just the final document download page.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
