### PR TITLE
Change header logo link to www.gov.uk

### DIFF
--- a/app/templates/document_download_template.html
+++ b/app/templates/document_download_template.html
@@ -38,7 +38,8 @@
 
 {% block header %}
   {{ govukHeader({
-    "assetsPath": "/static/images/"
+    "assetsPath": "/static/images/",
+    "homepageUrl": "https://www.gov.uk"
   }) }}
 {% endblock %}
 


### PR DESCRIPTION
It used to point at documents.service.gov.uk but this gives you a 404 page which we think isn't that useful. Instead we will change it to www.gov.uk (still not super useful but at least isn't a confusing 404 page)

You can see the configuration for this in
https://github.com/LandRegistry/govuk-frontend-jinja/blob/2.1.0/govuk_frontend_jinja/templates/components/header/macro.html



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
