### PR TITLE
Return "file unavailable" if past expiry date

### DIFF
--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -55,16 +55,13 @@ def landing(service_id, document_id):
     contact_info_type = assess_contact_type(service_contact_info)
     metadata = _get_document_metadata(service_id, document_id, key)
 
-    if not metadata:
+    if not metadata or document_has_expired(metadata["available_until"]):
         return render_template(
             "views/file_unavailable.html",
             service_name=service["data"]["name"],
             service_contact_info=service_contact_info,
             contact_info_type=contact_info_type,
         )
-
-    if document_has_expired(metadata["available_until"]):
-        abort(404)
 
     if "confirm_email" not in metadata:
         current_app.logger.info(
@@ -102,16 +99,13 @@ def confirm_email_address(service_id, document_id):
     service_name = service["data"]["name"]
     contact_info_type = assess_contact_type(service_contact_info)
 
-    if not metadata:
+    if not metadata or document_has_expired(metadata["available_until"]):
         return render_template(
             "views/file_unavailable.html",
             service_name=service_name,
             service_contact_info=service_contact_info,
             contact_info_type=contact_info_type,
         )
-
-    if document_has_expired(metadata["available_until"]):
-        abort(404)
 
     if metadata["confirm_email"] is False:
         return redirect(url_for(".download_document", service_id=service_id, document_id=document_id, key=key))
@@ -172,16 +166,13 @@ def download_document(service_id, document_id):
     service_contact_info = service["data"]["contact_link"]
     contact_info_type = assess_contact_type(service_contact_info)
 
-    if not metadata:
+    if not metadata or document_has_expired(metadata["available_until"]):
         return render_template(
             "views/file_unavailable.html",
             service_name=service["data"]["name"],
             service_contact_info=service_contact_info,
             contact_info_type=contact_info_type,
         )
-
-    if document_has_expired(metadata["available_until"]):
-        abort(404)
 
     return render_template(
         "views/download.html",


### PR DESCRIPTION
We have some unusual behaviour are files at the moment:

1) If the file isn't present in S3, we show a "file unavailable" page. 2) If the file is available but the custom retention period has passed, we serve a 404.

This can result in a user seeing a 404 page (which doesn't have service contact info) if they try to access the file soon after the expiry date has passed (when the file hasn't been deleted from S3) yet.

Let's always serve the "file unavailable" page in this situation.

| Before | After |
|---|---|
| <img width="678" alt="image" src="https://user-images.githubusercontent.com/2920760/207849171-61d9250f-7d1b-4f0f-a342-28a80e53a71b.png"> | <img width="537" alt="image" src="https://user-images.githubusercontent.com/2920760/207849120-b387627f-37a9-4db1-8f09-37d2fb9811a2.png"> |




---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
