### PR TITLE
Bump isort to 5.12.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
   - id: flake8
     name: flake8 (python)
 - repo: https://github.com/PyCQA/isort
-  rev: 5.10.1
+  rev: 5.12.0
   hooks:
     - id: isort
       name: isort (python)

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,8 +1,8 @@
 -r requirements.txt
 
-black==22.8.0
-flake8==5.0.4
-isort==5.12.0
+black==22.8.0  # Also update `.pre-commit-config.yaml` if this changes
+flake8==5.0.4  # Also update `.pre-commit-config.yaml` if this changes
+isort==5.12.0  # Also update `.pre-commit-config.yaml` if this changes
 
 pytest==7.1.2
 pytest-mock==3.8.2

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -2,7 +2,7 @@
 
 black==22.8.0
 flake8==5.0.4
-isort==5.10.1
+isort==5.12.0
 
 pytest==7.1.2
 pytest-mock==3.8.2


### PR DESCRIPTION
Installing isort from scratch via pre-commit has broken due to a release from Poetry.

https://levelup.gitconnected.com/fix-runtimeerror-poetry-isort-5db7c67b60ff

The solution is to bump to the latest isort version.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
