### PR TITLE
Bump govuk-frontend from 4.0.1 to 4.5.0

### DIFF
--- a/app/assets/javascripts/govuk-frontend-local.mjs
+++ b/app/assets/javascripts/govuk-frontend-local.mjs
@@ -6,10 +6,22 @@
 //
 // Exported items will be added to the window.GOVUK namespace.
 // For example, `export { Frontend }` will assign `Frontend` to `window.Frontend`
-import { nodeListForEach } from 'govuk-frontend/govuk/common'
-import Button from 'govuk-frontend/govuk/components/button/button'
-import ErrorSummary from 'govuk-frontend/govuk/components/error-summary/error-summary'
-import SkipLink from 'govuk-frontend/govuk/components/skip-link/skip-link'
+import { Button, ErrorSummary, SkipLink } from 'govuk-frontend'
+
+// Copied from GOVUK Frontend manually as the 'govuk-frontend' package doesn't export it
+//
+// TODO: Ideally this would be a NodeList.prototype.forEach polyfill
+// This seems to fail in IE8, requires more investigation.
+// See: https://github.com/imagitama/nodelist-foreach-polyfill
+//
+function nodeListForEach (nodes, callback) {
+  if (window.NodeList.prototype.forEach) {
+    return nodes.forEach(callback)
+  }
+  for (var i = 0; i < nodes.length; i++) {
+    callback.call(window, nodes[i], i, nodes);
+  }
+}
 
 // Copy of the initAll function from https://github.com/alphagov/govuk-frontend/blob/v3.5.0/src/govuk/all.js
 // except it only includes, and initialises, the components used by this application.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "govuk-frontend": "4.0.1"
+        "govuk-frontend": "4.5.0"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "21.0.1",
@@ -2586,9 +2586,9 @@
       "license": "MIT"
     },
     "node_modules/govuk-frontend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.0.1.tgz",
-      "integrity": "sha512-X+B88mqYHoxAz0ID87Uxo3oHqdKBRnNHd3Cz8+u8nvQUAsrEzROFLK+t7sAu7e+fKqCCrJyIgx6Cmr6dIGnohQ==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.5.0.tgz",
+      "integrity": "sha512-gZHDqf5vdlHjmx0NGJiNT12XLyR3d5KCS4AnlC3xTWOObJ0kQROrkIFyp3w4/PY3EQiYdgacVaJ6lizzygnzYw==",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -8958,9 +8958,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.0.1.tgz",
-      "integrity": "sha512-X+B88mqYHoxAz0ID87Uxo3oHqdKBRnNHd3Cz8+u8nvQUAsrEzROFLK+t7sAu7e+fKqCCrJyIgx6Cmr6dIGnohQ=="
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.5.0.tgz",
+      "integrity": "sha512-gZHDqf5vdlHjmx0NGJiNT12XLyR3d5KCS4AnlC3xTWOObJ0kQROrkIFyp3w4/PY3EQiYdgacVaJ6lizzygnzYw=="
     },
     "graceful-fs": {
       "version": "4.2.8",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": "Government Digital Service",
   "license": "MIT",
   "dependencies": {
-    "govuk-frontend": "4.0.1"
+    "govuk-frontend": "4.5.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "21.0.1",


### PR DESCRIPTION
Only includes minor changes, none of which break the pages in any of the browsers we support[^1].

Full list of changes: https://github.com/alphagov/govuk-frontend/releases

[^1]: [manuals page on browser, email client and assistive tech support](https://github.com/alphagov/notifications-manuals/wiki/Support-for-browsers,-email-clients-and-assistive-technologies)

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
