### PR TITLE
Bump werkzeug to address vulnerability

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -7,7 +7,7 @@ Flask-WTF==1.0.1
 # Should be pinned until a new gunicorn release greater than 20.1.0 comes out. (Due to eventlet v0.33 compatibility issues)
 git+https://github.com/benoitc/gunicorn.git@1299ea9e967a61ae2edebe191082fd169b864c64#egg=gunicorn[eventlet]==20.1.0
 whitenoise==6.2.0  #manages static assets
-werkzeug==2.2.2
+werkzeug==2.2.3
 
 notifications-python-client==6.3.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -148,7 +148,7 @@ urllib3==1.26.7
     #   requests
 webencodings==0.5.1
     # via bleach
-werkzeug==2.2.2
+werkzeug==2.2.3
     # via
     #   -r requirements.in
     #   flask


### PR DESCRIPTION
https://github.com/pallets/werkzeug/security/advisories/GHSA-xg9f-g7g7-2323



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
