### PR TITLE
Change NOTIFY_LOG_PATH to an environment variable in the app config

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -23,7 +23,7 @@ class Config(object):
     ROUTE_SECRET_KEY_1 = os.environ.get("ROUTE_SECRET_KEY_1", "")
 
     # needs to refer to notify for utils
-    NOTIFY_LOG_PATH = "/home/vcap/logs/app.log"
+    NOTIFY_LOG_PATH = os.getenv("NOTIFY_LOG_PATH")
 
 
 class Development(Config):

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -29,6 +29,7 @@ applications:
     ADMIN_CLIENT_SECRET: {{ ADMIN_CLIENT_SECRET }}
     API_HOST_NAME: {{ API_HOST_NAME }}
     SECRET_KEY: '{{ SECRET_KEY_FRONTEND }}'
+    NOTIFY_LOG_PATH: /home/vcap/logs/app.log
 
     NOTIFY_APP_NAME: document-download-frontend
     FLASK_APP: application.py


### PR DESCRIPTION
to fix document_download_frontend ECS service not running tasks due to being unable to write to logs file, to keep consistency with other apps such as notifications-antivirus, api, admin.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
