### PR TITLE
Bump version of notification_utils used

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -14,5 +14,5 @@ notifications-python-client==6.3.0
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-git+https://github.com/alphagov/notifications-utils.git@56.0.3
+git+https://github.com/alphagov/notifications-utils.git@57.1.0
 govuk-frontend-jinja==2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,6 @@ awscli==1.21.5
     # via awscli-cwlogs
 awscli-cwlogs==1.4.6
     # via -r requirements.in
-bleach==4.1.0
-    # via notifications-utils
 boto3==1.19.5
     # via notifications-utils
 botocore==1.22.5
@@ -84,20 +82,16 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==6.3.0
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@56.0.3
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@57.1.0
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils
-packaging==21.0
-    # via bleach
 phonenumbers==8.12.36
     # via notifications-utils
 pyasn1==0.4.8
     # via rsa
 pyjwt==2.4.0
     # via notifications-python-client
-pyparsing==3.0.3
-    # via packaging
 pypdf2==2.10.6
     # via notifications-utils
 pyproj==3.3.0
@@ -133,7 +127,6 @@ shapely==1.8.0
 six==1.16.0
     # via
     #   awscli-cwlogs
-    #   bleach
     #   eventlet
     #   python-dateutil
 smartypants==2.0.1
@@ -146,8 +139,6 @@ urllib3==1.26.7
     # via
     #   botocore
     #   requests
-webencodings==0.5.1
-    # via bleach
 werkzeug==2.2.3
     # via
     #   -r requirements.in


### PR DESCRIPTION
to fix errors running this app in ECS.

The `notifcations_utils` version was bumped from `56.0.3` to `57.1.0`.
The changelog stated a breaking change:

> `57.0.0`
Breaking changes to `field.Field`:
The `html` argument must now be `escape` or `passthrough`. `strip` is no longer valid
The default value of the `html` argument is now escape not `strip`
Removal of `formatters.strip_html`:



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
