### PR TITLE
Add Config class NOTIFY_RUNTIME_PLATFORM variable

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -9,6 +9,7 @@ class Config(object):
     SECRET_KEY = os.environ.get("SECRET_KEY")
 
     API_HOST_NAME = os.environ.get("API_HOST_NAME")
+    NOTIFY_RUNTIME_PLATFORM = os.environ.get("NOTIFY_RUNTIME_PLATFORM")
 
     CHECK_PROXY_HEADER = False
 

--- a/app/config.py
+++ b/app/config.py
@@ -9,7 +9,7 @@ class Config(object):
     SECRET_KEY = os.environ.get("SECRET_KEY")
 
     API_HOST_NAME = os.environ.get("API_HOST_NAME")
-    NOTIFY_RUNTIME_PLATFORM = os.environ.get("NOTIFY_RUNTIME_PLATFORM")
+    NOTIFY_RUNTIME_PLATFORM = os.environ.get("NOTIFY_RUNTIME_PLATFORM", "paas")
 
     CHECK_PROXY_HEADER = False
 


### PR DESCRIPTION
so that when the instance variable app.config["NOTIFY_RUNTIME_PLATFORM"] is called by notifications_utils, it is populated. This is intended to allow the 'stop writing to log file' flow on ECS, when app.config["NOTIFY_RUNTIME_PLATFORM"] = "ecs"



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
