### PR TITLE
Install curl in docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,6 +16,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
     build-essential \
+    curl \
     git \
     && apt-get -y clean \
     && rm -rf /var/lib/apt/lists/* /tmp/*


### PR DESCRIPTION
Similar to https://github.com/alphagov/document-download-api/pull/243

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
