### PR TITLE
Remove `ADMIN_BASE_URL` and some unnecessary parts of the CSP

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -14,7 +14,6 @@ from werkzeug.routing import BaseConverter, ValidationError
 from app.asset_fingerprinter import AssetFingerprinter
 from app.config import configs
 from app.notify_client.service_api_client import ServiceApiClient
-from app.utils import get_cdn_domain
 
 statsd_client = StatsdClient()
 asset_fingerprinter = AssetFingerprinter()
@@ -90,7 +89,7 @@ def useful_headers_after_request(response):
             "connect-src 'self';"
             "object-src 'self';"
             "font-src 'self' data:;"
-            "img-src 'self' *.notifications.service.gov.uk {} data:;".format(get_cdn_domain())
+            "img-src 'self' data:;"
         ),
     )
     if "Cache-Control" in response.headers:

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -90,6 +90,7 @@ def useful_headers_after_request(response):
             "object-src 'self';"
             "font-src 'self' data:;"
             "img-src 'self' data:;"
+            "frame-src 'none'"
         ),
     )
     if "Cache-Control" in response.headers:

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -86,12 +86,11 @@ def useful_headers_after_request(response):
         "Content-Security-Policy",
         (
             "default-src 'self' 'unsafe-inline';"
-            "script-src 'self' *.google-analytics.com 'unsafe-inline' 'unsafe-eval' data:;"
-            "connect-src 'self' *.google-analytics.com;"
+            "script-src 'self' 'unsafe-inline' 'unsafe-eval' data:;"
+            "connect-src 'self';"
             "object-src 'self';"
             "font-src 'self' data:;"
-            "img-src 'self' *.google-analytics.com *.notifications.service.gov.uk {} data:;"
-            "frame-src www.youtube.com;".format(get_cdn_domain())
+            "img-src 'self' *.notifications.service.gov.uk {} data:;".format(get_cdn_domain())
         ),
     )
     if "Cache-Control" in response.headers:

--- a/app/config.py
+++ b/app/config.py
@@ -3,7 +3,6 @@ import os
 
 class Config(object):
     # if we're not on cloudfoundry, we can get to this app from localhost. but on cloudfoundry its different
-    ADMIN_BASE_URL = os.environ.get("ADMIN_BASE_URL", "http://localhost:6012")
     ADMIN_CLIENT_SECRET = os.environ.get("ADMIN_CLIENT_SECRET")
     ADMIN_CLIENT_USER_NAME = "notify-admin"
     SECRET_KEY = os.environ.get("SECRET_KEY")
@@ -29,7 +28,6 @@ class Config(object):
 
 class Development(Config):
     API_HOST_NAME = os.environ.get("API_HOST_NAME", "http://localhost:6011")
-    ADMIN_BASE_URL = os.environ.get("ADMIN_BASE_URL", "http://localhost:6012")
     DOCUMENT_DOWNLOAD_API_HOST_NAME = os.environ.get("DOCUMENT_DOWNLOAD_API_HOST_NAME", "http://localhost:7000")
 
     ADMIN_CLIENT_SECRET = "dev-notify-secret-key"
@@ -47,7 +45,6 @@ class Test(Development):
     SERVER_NAME = "document-download-frontend.gov"
 
     API_HOST_NAME = "http://test-notify-api"
-    ADMIN_BASE_URL = "http://test-notify-admin"
     DOCUMENT_DOWNLOAD_API_HOST_NAME = "http://test-doc-download-api"
 
 

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -5,7 +5,7 @@ from urllib import parse
 import requests
 from dateutil import parser
 from flask import abort, current_app, redirect, render_template, request, url_for
-from jinja2 import Markup
+from markupsafe import Markup
 from notifications_python_client.errors import HTTPError
 from werkzeug.exceptions import TooManyRequests
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,22 +1,8 @@
 import re
 from datetime import date
-from urllib.parse import urlparse
 
 from dateutil import parser
-from flask import current_app
 from notifications_utils.recipients import EMAIL_REGEX_PATTERN
-
-
-def get_cdn_domain():
-    parsed_uri = urlparse(current_app.config["ADMIN_BASE_URL"])
-
-    if parsed_uri.netloc.startswith("localhost"):
-        return "static-logos.notify.tools"
-
-    subdomain = parsed_uri.hostname.split(".")[0]
-    domain = parsed_uri.netloc[len(subdomain + ".") :]
-
-    return "static-logos.{}".format(domain)
 
 
 def assess_contact_type(service_contact_info):

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -25,7 +25,6 @@ applications:
   health-check-http-endpoint: '/_status'
 
   env:
-    ADMIN_BASE_URL: {{ ADMIN_BASE_URL }}
     ADMIN_CLIENT_SECRET: {{ ADMIN_CLIENT_SECRET }}
     API_HOST_NAME: {{ API_HOST_NAME }}
     SECRET_KEY: '{{ DOCUMENT_DOWNLOAD_SECRET_KEY_FRONTEND }}'

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -400,7 +400,7 @@ def test_confirm_email_address_page_shows_429_error_page_if_auth_rate_limited(
     assert normalize_spaces(page.title.text) == "Cannot access document – GOV.UK"
     assert normalize_spaces(page.h1.text) == "Cannot access document"
 
-    assert page.find("a", text="Go back to confirm your email address").get("href") == (
+    assert page.find("a", string="Go back to confirm your email address").get("href") == (
         "http://document-download-frontend.gov/"
         f"d/{uuid_to_base64(service_id)}/{uuid_to_base64(document_id)}/confirm-email-address?key=1234"
     )

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -1,18 +1,6 @@
 import pytest
 
-from app.utils import assess_contact_type, bytes_to_pretty_file_size, get_cdn_domain
-
-
-def test_get_cdn_domain_on_localhost(client, mocker):
-    mocker.patch.dict("app.current_app.config", values={"ADMIN_BASE_URL": "http://localhost:6012"})
-    domain = get_cdn_domain()
-    assert domain == "static-logos.notify.tools"
-
-
-def test_get_cdn_domain_on_non_localhost(client, mocker):
-    mocker.patch.dict("app.current_app.config", values={"ADMIN_BASE_URL": "https://some.admintest.com"})
-    domain = get_cdn_domain()
-    assert domain == "static-logos.admintest.com"
+from app.utils import assess_contact_type, bytes_to_pretty_file_size
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This change gets rid of the `ADMIN_BASE_URL` environment variable in order to make it clear that this app does not need to connect to admin. Removing the unneeded `get_cdn_domain` from the content security policy lets us get rid of that variable.

I've also removed a couple of other things from the CSP at the same time. There are probably more things that can also be removed later, but this change just gets rid of a few of the more obvious ones.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
