### PR TITLE
Include `flask` extra for sentry

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -16,4 +16,4 @@ awscli-cwlogs>=1.4,<1.5
 
 git+https://github.com/alphagov/notifications-utils.git@57.1.0
 govuk-frontend-jinja==2.1.0
-sentry_sdk>=1.0.0,<2.0.0
+sentry_sdk[flask]>=1.0.0,<2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,8 @@ awscli==1.21.5
     # via awscli-cwlogs
 awscli-cwlogs==1.4.6
     # via -r requirements.in
+blinker==1.6.2
+    # via sentry-sdk
 boto3==1.19.5
     # via notifications-utils
 botocore==1.22.5
@@ -42,6 +44,7 @@ flask==2.1.1
     #   flask-redis
     #   flask-wtf
     #   notifications-utils
+    #   sentry-sdk
 flask-redis==0.4.0
     # via notifications-utils
 flask-wtf==1.0.1
@@ -123,7 +126,7 @@ s3transfer==0.5.0
     # via
     #   awscli
     #   boto3
-sentry-sdk==1.21.1
+sentry-sdk[flask]==1.21.1
     # via -r requirements.in
 shapely==1.8.0
     # via notifications-utils


### PR DESCRIPTION
We were missing the `blinker` dependency for Sentry, so the integration couldn't instrument on this app. We didn't notice this because all of the other apps just happen to have that dependency installed already.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
