### PR TITLE
Bump notifications python client

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -9,7 +9,7 @@ git+https://github.com/benoitc/gunicorn.git@1299ea9e967a61ae2edebe191082fd169b86
 whitenoise==6.2.0  #manages static assets
 werkzeug==2.2.3
 
-notifications-python-client==6.3.0
+notifications-python-client==8.0.1
 
 # PaaS
 awscli-cwlogs>=1.4,<1.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -84,7 +84,7 @@ markupsafe==2.1.1
     #   wtforms
 mistune==0.8.4
     # via notifications-utils
-notifications-python-client==6.3.0
+notifications-python-client==8.0.1
     # via -r requirements.in
 notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@57.1.0
     # via -r requirements.in


### PR DESCRIPTION
Pulls in the new formatting for log lines emitted by the python client.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
