### PR TITLE
Add version file make step; tag release for sentry

### DIFF
--- a/app/performance.py
+++ b/app/performance.py
@@ -26,6 +26,13 @@ def init_performance_monitoring():
 
         traces_sampler = partial(sentry_sampler, sample_rate=trace_sample_rate)
 
+        try:
+            from app.version import __git_commit__
+
+            release = __git_commit__
+        except ImportError:
+            release = None
+
         sentry_sdk.init(
             dsn=sentry_dsn,
             environment=environment,
@@ -33,4 +40,5 @@ def init_performance_monitoring():
             send_default_pii=send_pii,
             request_bodies=send_request_bodies,
             traces_sampler=traces_sampler,
+            release=release,
         )


### PR DESCRIPTION
Copies the 'generate-version-file' step that we have in API and admin, and uses that (if possible) when initialising Sentry. This will let us track releases and tie errors to new releases.

We'll need to update the deployment pipeline to generate this file, but that can happen separately.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
