### PR TITLE
Use the `download.` subdomain for doc-download-api across all environments

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -46,7 +46,7 @@ class Test(Development):
     SERVER_NAME = "document-download-frontend.gov"
 
     API_HOST_NAME = "http://test-notify-api"
-    DOCUMENT_DOWNLOAD_API_HOST_NAME = "http://test-doc-download-api"
+    DOCUMENT_DOWNLOAD_API_HOST_NAME = "https://download.test-doc-download-api.gov.uk"
 
 
 class Preview(Config):

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -152,9 +152,8 @@ def confirm_email_address(service_id, document_id):
             # this works fine when they're both under the same domain
             # but when we're in a subdomain, we need to allow the cookie to be sent to subdomains too
             # docs: https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#domain_attribute
-            if current_app.config["DOCUMENT_DOWNLOAD_API_HOST_NAME"].startswith("https://download."):
-                cookie_domain = current_app.config["DOCUMENT_DOWNLOAD_API_HOST_NAME"].replace("https://download.", "")
-                set_cookie_values["domain"] = cookie_domain
+            cookie_domain = current_app.config["DOCUMENT_DOWNLOAD_API_HOST_NAME"].replace("https://download.", "")
+            set_cookie_values["domain"] = cookie_domain
 
             response = redirect(url_for(".download_document", service_id=service_id, document_id=document_id, key=key))
             response.set_cookie(**set_cookie_values)

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -35,6 +35,20 @@ def status():
     return "ok", 200
 
 
+@main.route("/services/_status")
+@main.route("/services/<uuid:service_id>/documents/<uuid:document_id>", methods=["GET"])
+@main.route("/services/<uuid:service_id>/documents/<uuid:document_id>.<extension>", methods=["GET"])
+@main.route("/services/<uuid:service_id>/documents/<uuid:document_id>/check", methods=["GET"])
+def services(service_id=None, document_id=None, extension=None):
+    api_host = current_app.config["DOCUMENT_DOWNLOAD_API_HOST_NAME"]
+    path = request.path
+    query_string = request.query_string.decode("utf-8")
+    if len(query_string) > 1:
+        return redirect(f"{api_host}{path}?{query_string}", 301)
+    else:
+        return redirect(f"{api_host}{path}", 301)
+
+
 @main.route("/.well-known/security.txt", methods=["GET"])
 @main.route("/security.txt", methods=["GET"])
 def security_policy():

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -153,7 +153,7 @@ def confirm_email_address(service_id, document_id):
             # but when we're in a subdomain, we need to allow the cookie to be sent to subdomains too
             # docs: https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#domain_attribute
             if current_app.config["DOCUMENT_DOWNLOAD_API_HOST_NAME"].startswith("https://download."):
-                cookie_domain = current_app.config["DOCUMENT_DOWNLOAD_API_HOST_NAME"].replace("https://download.", ".")
+                cookie_domain = current_app.config["DOCUMENT_DOWNLOAD_API_HOST_NAME"].replace("https://download.", "")
                 set_cookie_values["domain"] = cookie_domain
 
             response = redirect(url_for(".download_document", service_id=service_id, document_id=document_id, key=key))

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -32,7 +32,12 @@ applications:
 
     NOTIFY_APP_NAME: document-download-frontend
     FLASK_APP: application.py
+    {% if environment == "preview" %}
+    DOCUMENT_DOWNLOAD_API_HOST_NAME: https://download.{{ hostname }}
+    {% else %}
     DOCUMENT_DOWNLOAD_API_HOST_NAME: https://{{ hostname }}
+    {% endif %}
+
     NOTIFY_ENVIRONMENT: {{ environment }}
     AWS_ACCESS_KEY_ID: {{ DOCUMENT_DOWNLOAD_AWS_ACCESS_KEY_ID }}
     AWS_SECRET_ACCESS_KEY: {{ DOCUMENT_DOWNLOAD_AWS_SECRET_ACCESS_KEY }}

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -33,6 +33,24 @@ def test_security_policy_redirects_to_policy(client, url):
 
 
 @pytest.mark.parametrize(
+    "url",
+    [
+        "/services/_status",
+        "/services/11111111-1111-4111-1111-111111111111/documents/22222222-2222-4222-2222-222222222222",
+        "/services/11111111-1111-4111-1111-111111111111/documents/22222222-2222-4222-2222-222222222222.pdf",
+        "/services/11111111-1111-4111-1111-111111111111/documents/22222222-2222-4222-2222-222222222222/check",
+        "/services/11111111-1111-4111-1111-111111111111/documents/22222222-2222-4222-2222-222222222222/check?key=123456",
+        "/services/11111111-1111-4111-1111-111111111111/documents/22222222-2222-4222-2222-222222222222/check?random_parameter=xyz",
+    ],
+)
+def test_services_view_redirects_to_api(client, url):
+    response = client.get(url)
+
+    assert response.status_code == 301
+    assert response.location == f"http://test-doc-download-api{url}"
+
+
+@pytest.mark.parametrize(
     "view, method",
     [
         ("main.landing", "get"),

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -464,7 +464,7 @@ def test_confirm_email_address_page_redirects_and_sets_cookie_on_success(
     )
     assert (
         response.headers["Set-Cookie"]
-        == "document_access_signed_data=blah; Domain=.test-doc-download-api.gov.uk; HttpOnly; Path=/my/file/path"
+        == "document_access_signed_data=blah; Domain=test-doc-download-api.gov.uk; HttpOnly; Path=/my/file/path"
     )
 
 

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -47,7 +47,7 @@ def test_services_view_redirects_to_api(client, url):
     response = client.get(url)
 
     assert response.status_code == 301
-    assert response.location == f"http://test-doc-download-api{url}"
+    assert response.location == f"https://download.test-doc-download-api.gov.uk{url}"
 
 
 @pytest.mark.parametrize(
@@ -462,9 +462,9 @@ def test_confirm_email_address_page_redirects_and_sets_cookie_on_success(
     assert response.location == url_for(
         "main.download_document", service_id=service_id, document_id=document_id, key=key
     )
-    assert any(
-        header == ("Set-Cookie", "document_access_signed_data=blah; HttpOnly; Path=/my/file/path")
-        for header in response.headers
+    assert (
+        response.headers["Set-Cookie"]
+        == "document_access_signed_data=blah; Domain=.test-doc-download-api.gov.uk; HttpOnly; Path=/my/file/path"
     )
 
 


### PR DESCRIPTION
### ⚠️ Depends on ⚠️ 
- https://github.com/alphagov/document-download-api/pull/253
- https://github.com/alphagov/notifications-aws/pull/1451

This PR **will** start using the new subdomain introduced in the PRs above.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
