### PR TITLE
Update create-droplet script

### DIFF
--- a/manifest-droplet.yml
+++ b/manifest-droplet.yml
@@ -1,0 +1,12 @@
+---
+applications:
+- name: ((app_name))
+  stack: cflinuxfs3
+  processes:
+  - type: web
+    instances: 0
+    memory: 1024M
+    disk_quota: 1024M
+    log-rate-limit-per-second: 1M
+    health-check-type: port
+  buildpack: python_buildpack

--- a/scripts/create-droplet.sh
+++ b/scripts/create-droplet.sh
@@ -1,24 +1,31 @@
-!/usr/bin/env bash
+#!/usr/bin/env bash
 
 set -eux
 
 CF_SPACE=${CF_SPACE:-monitoring}
 
-[[ ! -f ./.git/short_ref ]] && $(git rev-parse --short HEAD) > ./.git/short_ref
-GIT_REF=$(cat .git/short_ref)
+
+if [[ -f .git/short_ref ]]; then
+  GIT_REF=$(cat .git/short_ref)
+else
+  GIT_REF=$(git rev-parse --short HEAD)
+fi
 DROPLET_BUILD_APP="droplet-build-document-download-frontend-${GIT_REF}"
 
 echo "Creating ${DROPLET_BUILD_APP} in ${CF_SPACE}"
 cf target -s ${CF_SPACE}
 cf create-app ${DROPLET_BUILD_APP}
 
+echo "Applying droplet build app manifest..."
+cf apply-manifest -f manifest-droplet.yml --var app_name=${DROPLET_BUILD_APP}
+
 echo "Creating package..."
 cf create-package ${DROPLET_BUILD_APP} -p .
-PACKAGE_GUID=$(cf packages ${DROPLET_BUILD_APP} | tail -n 1 | cut -d" " -f 1)
+PACKAGE_GUID=$(cf curl /v3/apps/$(cf app ${DROPLET_BUILD_APP} --guid)/packages | jq -r '[.resources[] | {created_at, guid}] | sort_by(.created_at) | reverse | .[0].guid')
 
 echo "Staging package to create droplet..."
 cf stage-package ${DROPLET_BUILD_APP} --package-guid ${PACKAGE_GUID}
-DROPLET_GUID=$(cf droplets ${DROPLET_BUILD_APP} | tail -n 1 | cut -d" " -f 1)
+DROPLET_GUID=$(cf curl /v3/apps/$(cf app ${DROPLET_BUILD_APP} --guid)/droplets | jq -r '[.resources[] | {created_at, guid}] | sort_by(.created_at) | reverse | .[0].guid')
 echo "Created droplet ${DROPLET_GUID}"
 
 CURRENT_TIME=$(date '+%Y-%m-%dT%H-%M-%SZ')


### PR DESCRIPTION
Some small generic updates to the create-droplet script that:
* uses git rev-parse directly if .git/short_ref isn't available, rather than creating a file which caches a static hash.
* retrieves the latest package and droplet guid for an app via cf curl, rather than the last line of some structured output (which is the _oldest_ package or droplet for a given app).

We also add a manifest for the droplet-builder app so that we can specify only the python buildpack, otherwise buildpack detection kicks in and we end up trying to build a node app. (failed build: https://concourse.notify.tools/teams/notify/pipelines/apps/jobs/build-document-download-frontend/builds/66)

These are 'good enough' fixes considering that PaaS buildpacks/etc will all be retired within the next 6 months as we migrate to AWS.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
