### PR TITLE
Fix requirements (unable to freeze)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,22 +4,22 @@
 #
 #    pip-compile requirements.in
 #
-awscli==1.21.5
+awscli==1.29.5
     # via awscli-cwlogs
 awscli-cwlogs==1.4.6
     # via -r requirements.in
 blinker==1.6.2
     # via sentry-sdk
-boto3==1.19.5
+boto3==1.28.5
     # via notifications-utils
-botocore==1.22.5
+botocore==1.31.5
     # via
     #   awscli
     #   boto3
     #   s3transfer
 cachetools==4.2.4
     # via notifications-utils
-certifi==2022.12.07
+certifi==2022.12.7
     # via
     #   pyproj
     #   requests
@@ -108,7 +108,7 @@ python-json-logger==2.0.2
     # via notifications-utils
 pytz==2021.3
     # via notifications-utils
-pyyaml==5.4.1
+pyyaml==6.0.1
     # via
     #   awscli
     #   notifications-utils
@@ -122,7 +122,7 @@ requests==2.31.0
     #   notifications-utils
 rsa==4.7.2
     # via awscli
-s3transfer==0.5.0
+s3transfer==0.6.1
     # via
     #   awscli
     #   boto3


### PR DESCRIPTION
For the last few days we've been unable to run `make freeze-requirements`, getting errors like this:

```
...
            raise AttributeError(attr)
        AttributeError: cython_sources
        [end of output]

    note: This error originates from a subprocess, and is likely not a problem with pip.
...
pip._internal.exceptions.InstallationSubprocessError: Getting requirements to build wheel exited with 1

make: *** [freeze-requirements] Error 1
```

From some searches online this seems related to a release of cython3 that just came out, which PyYAML uses.

yaml/pyyaml#724

There is now a new release of PyYAML (6.0.1) that fixes the issue, so let's bump to that. In order to bump to that, we need to bump boto3, botocore, awscrt and s3transfer as well.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
