### PR TITLE
Use the doc-download-api subdomain across all environments

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -32,11 +32,7 @@ applications:
 
     NOTIFY_APP_NAME: document-download-frontend
     FLASK_APP: application.py
-    {% if environment == "preview" %}
     DOCUMENT_DOWNLOAD_API_HOST_NAME: https://download.{{ hostname }}
-    {% else %}
-    DOCUMENT_DOWNLOAD_API_HOST_NAME: https://{{ hostname }}
-    {% endif %}
 
     NOTIFY_ENVIRONMENT: {{ environment }}
     AWS_ACCESS_KEY_ID: {{ DOCUMENT_DOWNLOAD_AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
This is enabling the api subdomain for all environments.

This **will** start sending traffic through the new subdomain.


---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
