### PR TITLE
Split doc download API into external and internal routes

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -16,6 +16,7 @@ class Config(object):
     DEBUG = False
 
     DOCUMENT_DOWNLOAD_API_HOST_NAME = os.environ.get("DOCUMENT_DOWNLOAD_API_HOST_NAME")
+    DOCUMENT_DOWNLOAD_API_HOST_NAME_INTERNAL = os.environ.get("DOCUMENT_DOWNLOAD_API_HOST_NAME_INTERNAL")
 
     HEADER_COLOUR = "#FFBF47"  # $yellow
     HTTP_PROTOCOL = "http"
@@ -30,6 +31,9 @@ class Development(Config):
     SERVER_NAME = os.getenv("SERVER_NAME")
     API_HOST_NAME = os.environ.get("API_HOST_NAME", "http://localhost:6011")
     DOCUMENT_DOWNLOAD_API_HOST_NAME = os.environ.get("DOCUMENT_DOWNLOAD_API_HOST_NAME", "http://localhost:7000")
+    DOCUMENT_DOWNLOAD_API_HOST_NAME_INTERNAL = os.environ.get(
+        "DOCUMENT_DOWNLOAD_API_HOST_NAME", "http://localhost:7000"
+    )
 
     ADMIN_CLIENT_SECRET = "dev-notify-secret-key"
     SECRET_KEY = "dev-notify-secret-key"
@@ -47,6 +51,7 @@ class Test(Development):
 
     API_HOST_NAME = "http://test-notify-api"
     DOCUMENT_DOWNLOAD_API_HOST_NAME = "https://download.test-doc-download-api.gov.uk"
+    DOCUMENT_DOWNLOAD_API_HOST_NAME_INTERNAL = "https://download.test-doc-download-api-internal.gov.uk"
 
 
 class Preview(Config):

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -229,7 +229,7 @@ def _get_service_or_raise_error(service_id):
 
 def _get_document_metadata(service_id, document_id, key):
     check_file_url = "{}/services/{}/documents/{}/check?key={}".format(
-        current_app.config["DOCUMENT_DOWNLOAD_API_HOST_NAME"], service_id, document_id, key
+        current_app.config["DOCUMENT_DOWNLOAD_API_HOST_NAME_INTERNAL"], service_id, document_id, key
     )
     response = requests.get(check_file_url)
 
@@ -249,7 +249,7 @@ def _get_document_metadata(service_id, document_id, key):
 
 def _authenticate_access_to_document(service_id, document_id, key, email_address) -> Optional[dict]:
     auth_file_url = "{}/services/{}/documents/{}/authenticate".format(
-        current_app.config["DOCUMENT_DOWNLOAD_API_HOST_NAME"],
+        current_app.config["DOCUMENT_DOWNLOAD_API_HOST_NAME_INTERNAL"],
         service_id,
         document_id,
     )

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -33,6 +33,7 @@ applications:
     NOTIFY_APP_NAME: document-download-frontend
     FLASK_APP: application.py
     DOCUMENT_DOWNLOAD_API_HOST_NAME: https://download.{{ hostname }}
+    DOCUMENT_DOWNLOAD_API_HOST_NAME_INTERNAL: https://download.{{ hostname }}
 
     NOTIFY_ENVIRONMENT: {{ environment }}
     AWS_ACCESS_KEY_ID: {{ DOCUMENT_DOWNLOAD_AWS_ACCESS_KEY_ID }}

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -185,7 +185,7 @@ def test_404_hides_incorrect_credentials(
 
     rmock.get(
         "{}/services/{}/documents/{}/check?key={}".format(
-            current_app.config["DOCUMENT_DOWNLOAD_API_HOST_NAME"], service_id, document_id, key
+            current_app.config["DOCUMENT_DOWNLOAD_API_HOST_NAME_INTERNAL"], service_id, document_id, key
         ),
         status_code=400,
         json=json_response,
@@ -347,7 +347,7 @@ def test_confirm_email_address_page_shows_error_if_wrong_email_address(
 
     rmock.post(
         "{}/services/{}/documents/{}/authenticate".format(
-            current_app.config["DOCUMENT_DOWNLOAD_API_HOST_NAME"],
+            current_app.config["DOCUMENT_DOWNLOAD_API_HOST_NAME_INTERNAL"],
             service_id,
             document_id,
         ),
@@ -395,7 +395,7 @@ def test_confirm_email_address_page_shows_429_error_page_if_auth_rate_limited(
 
     rmock.post(
         "{}/services/{}/documents/{}/authenticate".format(
-            current_app.config["DOCUMENT_DOWNLOAD_API_HOST_NAME"],
+            current_app.config["DOCUMENT_DOWNLOAD_API_HOST_NAME_INTERNAL"],
             service_id,
             document_id,
         ),
@@ -441,7 +441,7 @@ def test_confirm_email_address_page_redirects_and_sets_cookie_on_success(
 
     rmock.post(
         "{}/services/{}/documents/{}/authenticate".format(
-            current_app.config["DOCUMENT_DOWNLOAD_API_HOST_NAME"],
+            current_app.config["DOCUMENT_DOWNLOAD_API_HOST_NAME_INTERNAL"],
             service_id,
             document_id,
         ),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,7 +67,7 @@ def document_has_metadata_no_confirmation(service_id, document_id, key, rmock, c
 
     rmock.get(
         "{}/services/{}/documents/{}/check?key={}".format(
-            current_app.config["DOCUMENT_DOWNLOAD_API_HOST_NAME"], service_id, document_id, key
+            current_app.config["DOCUMENT_DOWNLOAD_API_HOST_NAME_INTERNAL"], service_id, document_id, key
         ),
         json=json_response,
     )
@@ -87,7 +87,7 @@ def document_has_metadata_requires_confirmation(service_id, document_id, key, rm
 
     rmock.get(
         "{}/services/{}/documents/{}/check?key={}".format(
-            current_app.config["DOCUMENT_DOWNLOAD_API_HOST_NAME"], service_id, document_id, key
+            current_app.config["DOCUMENT_DOWNLOAD_API_HOST_NAME_INTERNAL"], service_id, document_id, key
         ),
         json=json_response,
     )


### PR DESCRIPTION
This means that internal traffic can be sent to the internal URL for doc download API and references to the external web address for doc download API can also be used in our code.

This won't change any behaviour on the PaaS as we set the internal and external hosts to be the same.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
