### PR TITLE
Set gunicorn keepalive to 90 seconds

### DIFF
--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -2,12 +2,9 @@ import os
 
 import gunicorn
 
-bind = "0.0.0.0:{}".format(os.getenv("PORT"))
-
 workers = 10
-
 worker_class = "eventlet"
 worker_connections = 1000
-
+bind = "0.0.0.0:{}".format(os.getenv("PORT"))
 errorlog = "/home/vcap/logs/gunicorn_error.log"
 gunicorn.SERVER_SOFTWARE = "None"

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -8,3 +8,4 @@ worker_connections = 1000
 bind = "0.0.0.0:{}".format(os.getenv("PORT"))
 errorlog = "/home/vcap/logs/gunicorn_error.log"
 gunicorn.SERVER_SOFTWARE = "None"
+keepalive = 90


### PR DESCRIPTION
Review commit by commit but essentially
- small spacing tidy up
- set 90 second keepalive to match https://github.com/alphagov/notifications-admin/pull/4826
---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
