### PR TITLE
Switch to use cflinuxfs4

### DIFF
--- a/manifest-droplet.yml
+++ b/manifest-droplet.yml
@@ -1,7 +1,7 @@
 ---
 applications:
 - name: ((app_name))
-  stack: cflinuxfs3
+  stack: cflinuxfs4
   processes:
   - type: web
     instances: 0

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -21,6 +21,7 @@ applications:
   services:
     - logit-ssl-syslog-drain
 
+  stack: cflinuxfs4
   health-check-type: http
   health-check-http-endpoint: '/_status'
 


### PR DESCRIPTION
What
----

Switch to use the PaaS cflinuxfs4 stack.

Why
----

cflinuxfs3 is currently the default on the PaaS. This is based off ubuntu 18.04. This stopped receiving updates after Apr 2023.

cflinuxfs4 will become the default on the PaaS after 27 Nov 2023.

The intention is to migrate all applications to cflinuxfs4 eventually.


---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
