### PR TITLE
Bump black to 23.10.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]
 - repo: https://github.com/psf/black
-  rev: 22.8.0
+  rev: 23.10.1
   hooks:
     - id: black
       name: black (python)

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 
-black==22.8.0  # Also update `.pre-commit-config.yaml` if this changes
+black==23.10.1  # Also update `.pre-commit-config.yaml` if this changes
 ruff==0.0.275  # Also update `.pre-commit-config.yaml` if this changes
 
 pytest==7.1.2


### PR DESCRIPTION

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
