### PR TITLE
Bump min instance count to 3

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -4,7 +4,7 @@ applications:
 
   memory: 1G
 
-  instances: 2
+  instances: 3
 
   buildpack: python_buildpack
 


### PR DESCRIPTION
We had an outage recently due to PaaS rolling our antivirus instances without waiting for a replacement to come up.

This is not a fix, but would give paas more time to perform the roll successfully before potentially causing an outage for us.

The exact cause of the incident is unknown but may be down to slow docker image pull times from github during the app rolling.

---

We probably don't _need_ to bump doc-dl apps, because they're droplet-based rather than docker image-based, but the cost is minimal and if it gives us more confidence until we move to ECS then I think that's still worth it.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
