### PR TITLE
requirements: notifications-utils: 66.0.0 -> 73.1.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -13,6 +13,6 @@ notifications-python-client==8.0.1
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@66.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@73.1.0
 govuk-frontend-jinja==2.1.0
 sentry_sdk[flask]>=1.0.0,<2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -89,13 +89,13 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@66.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@73.1.0
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils
 packaging==23.1
     # via gunicorn
-phonenumbers==8.12.36
+phonenumbers==8.13.26
     # via notifications-utils
 pyasn1==0.4.8
     # via rsa


### PR DESCRIPTION
https://trello.com/c/Q5S5m4ge/446-add-http-logging-to-all-of-our-ecs-apps

See https://github.com/alphagov/notifications-utils/pull/1077, this should bring flask request logging to apps in desired circumstances.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
