### PR TITLE
Update `ServiceApiClient` to add `X-Custom-Forwarder` header 

### DIFF
--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -1,19 +1,29 @@
 from __future__ import unicode_literals
 
+from notifications_python_client import __version__
 from notifications_python_client.notifications import BaseAPIClient
 
 
-class ServiceApiClient:
+class ServiceApiClient(BaseAPIClient):
     def __init__(self):
-        self.api_client = None
+        super().__init__("a" * 73, "b")
 
     def init_app(self, application):
-        self.api_client = BaseAPIClient(base_url=application.config["API_HOST_NAME"], api_key="a" * 75)
-        self.api_client.service_id = application.config["ADMIN_CLIENT_USER_NAME"]
-        self.api_client.api_key = application.config["ADMIN_CLIENT_SECRET"]
+        self.base_url = application.config["API_HOST_NAME"]
+        self.service_id = application.config["ADMIN_CLIENT_USER_NAME"]
+        self.api_key = application.config["ADMIN_CLIENT_SECRET"]
+        self.route_secret = application.config["ROUTE_SECRET_KEY_1"]
+
+    def generate_headers(self, api_token):
+        return {
+            "Content-type": "application/json",
+            "Authorization": f"Bearer {api_token}",
+            "X-Custom-Forwarder": self.route_secret,
+            "User-agent": f"NOTIFY-API-PYTHON-CLIENT/{__version__}",
+        }
 
     def get_service(self, service_id):
         """
         Retrieve a service.
         """
-        return self.api_client.get("/service/{0}".format(service_id))
+        return self.get(f"/service/{service_id}")

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-from notifications_python_client.notifications import NotificationsAPIClient
+from notifications_python_client.notifications import BaseAPIClient
 
 
 class ServiceApiClient:
@@ -8,7 +8,7 @@ class ServiceApiClient:
         self.api_client = None
 
     def init_app(self, application):
-        self.api_client = NotificationsAPIClient(base_url=application.config["API_HOST_NAME"], api_key="a" * 75)
+        self.api_client = BaseAPIClient(base_url=application.config["API_HOST_NAME"], api_key="a" * 75)
         self.api_client.service_id = application.config["ADMIN_CLIENT_USER_NAME"]
         self.api_client.api_key = application.config["ADMIN_CLIENT_SECRET"]
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,3 +7,4 @@ env =
     API_HOST_NAME=http://localhost:6014
     SECRET_KEY=test-notify-secret-key
     NOTIFY_ENVIRONMENT=test
+    ROUTE_SECRET_KEY_1=route-secret

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -1,9 +1,30 @@
+from notifications_python_client import __version__
+
 from app.notify_client.service_api_client import ServiceApiClient
+from application import application
 
 
 def test_client_gets_service(mocker):
     client = ServiceApiClient()
-    mock_api_client = mocker.patch.object(client, "api_client")
+    client.init_app(application)
+    perform_request_mock = mocker.patch.object(client, "_perform_request")
 
     client.get_service("foo")
-    mock_api_client.get.assert_called_once_with("/service/foo")
+
+    url = perform_request_mock.call_args_list[0][0][1]
+    assert url == "http://test-notify-api/service/foo"
+
+
+def test_client_passes_expected_headers(mocker):
+    client = ServiceApiClient()
+    client.init_app(application)
+    perform_request_mock = mocker.patch.object(client, "_perform_request")
+
+    client.get_service("foo")
+
+    request_kwargs = perform_request_mock.call_args_list[0][0][2]
+    headers = request_kwargs["headers"]
+    assert headers["Content-type"] == "application/json"
+    assert headers["Authorization"].startswith("Bearer ")
+    assert headers["X-Custom-Forwarder"] == "route-secret"
+    assert headers["User-agent"] == f"NOTIFY-API-PYTHON-CLIENT/{__version__}"


### PR DESCRIPTION
We want to pass the `X-Custom-Forwarder` header through in addition to
the three we were using because without it requests from this app to the
api are resulting in a 403 status code on ECS. This keeps things
consistent between the PaaS and ECS apps for now, but when everything is
migrated we can remove the need to check for the header in the apps.

To do this, the `ServiceApiClient` has been modified to inherit from the
`BaseAPIClient` instead of just using it. This means that we can
override the `generate_headers` method to add in `X-Custom-Forwarder`.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
