### PR TITLE
requirements: notifications-utils: 73.1.0 -> 74.0.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -13,6 +13,6 @@ notifications-python-client==8.0.1
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@73.1.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.0.0
 govuk-frontend-jinja==2.1.0
 sentry_sdk[flask]>=1.0.0,<2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,6 @@ cachetools==4.2.4
     # via notifications-utils
 certifi==2023.7.22
     # via
-    #   pyproj
     #   requests
     #   sentry-sdk
 charset-normalizer==2.0.7
@@ -89,9 +88,9 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@73.1.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.0.0
     # via -r requirements.in
-orderedset==2.0.3
+ordered-set==4.1.0
     # via notifications-utils
 packaging==23.1
     # via gunicorn
@@ -102,8 +101,6 @@ pyasn1==0.4.8
 pyjwt==2.4.0
     # via notifications-python-client
 pypdf==3.17.0
-    # via notifications-utils
-pyproj==3.6.0
     # via notifications-utils
 python-dateutil==2.8.2
     # via
@@ -135,8 +132,6 @@ segno==1.5.2
     # via notifications-utils
 sentry-sdk[flask]==1.32.0
     # via -r requirements.in
-shapely==1.8.0
-    # via notifications-utils
 six==1.16.0
     # via
     #   awscli-cwlogs


### PR DESCRIPTION
I mostly want this so I can send an example release through our pipelines to test a pipeline interlock mechanism. But it has the added bonus of making our pyup check go green again due to the dependency removal of pyproj.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
