### PR TITLE
Makefile: meaningless formatting tidy to trigger a test release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ freeze-requirements: ## create static requirements.txt
 	pip install --upgrade pip-tools
 	pip-compile requirements.in
 
+
 ## DEPLOYMENT
 
 .PHONY: preview


### PR DESCRIPTION
To test pipeline interlock mechanism I need to see a release go through this pipeline.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
