### PR TITLE
bump greenlet and eventlet version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,13 +31,13 @@ click==8.1.7
     # via flask
 colorama==0.4.3
     # via awscli
-dnspython==1.16.0
+dnspython==2.4.2
     # via eventlet
 docopt==0.6.2
     # via notifications-python-client
 docutils==0.15.2
     # via awscli
-eventlet==0.33.0
+eventlet==0.34.2
     # via gunicorn
 flask==3.0.0
     # via
@@ -56,10 +56,12 @@ govuk-bank-holidays==0.10
     # via notifications-utils
 govuk-frontend-jinja==2.1.0
     # via -r requirements.in
-greenlet==1.1.3
+greenlet==3.0.3
     # via eventlet
 gunicorn[eventlet]==21.2.0
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   gunicorn
 idna==3.3
     # via requests
 itsdangerous==2.1.2
@@ -129,7 +131,9 @@ s3transfer==0.6.1
 segno==1.5.2
     # via notifications-utils
 sentry-sdk[flask]==1.32.0
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   sentry-sdk
 six==1.16.0
     # via
     #   awscli-cwlogs


### PR DESCRIPTION
greenlet py3.11 support was added in 1.14 - lets bring it up to latest for futureproofing

older versions of eventlet try and use some out of date patching paths in dns. bumping to latest dns fixes these. Despite eventlet just setting ">=1.15.0" in their pyproject.toml, with python 3.11 we need dnspython >= 2.0.0 to get it to run succesfully

i've actually tested this by running with gunicorn locally


---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
