### PR TITLE
Bump utils to 74.2.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -12,6 +12,6 @@ notifications-python-client==8.0.1
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.2.0
 govuk-frontend-jinja==2.1.0
 sentry_sdk[flask]>=1.0.0,<2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,8 +50,6 @@ flask-redis==0.4.0
     # via notifications-utils
 flask-wtf==1.2.1
     # via -r requirements.in
-geojson==2.5.0
-    # via notifications-utils
 govuk-bank-holidays==0.10
     # via notifications-utils
 govuk-frontend-jinja==2.1.0
@@ -59,9 +57,7 @@ govuk-frontend-jinja==2.1.0
 greenlet==3.0.3
     # via eventlet
 gunicorn[eventlet]==21.2.0
-    # via
-    #   -r requirements.in
-    #   gunicorn
+    # via -r requirements.in
 idna==3.3
     # via requests
 itsdangerous==2.1.2
@@ -88,7 +84,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.2.0
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils
@@ -131,9 +127,7 @@ s3transfer==0.6.1
 segno==1.5.2
     # via notifications-utils
 sentry-sdk[flask]==1.32.0
-    # via
-    #   -r requirements.in
-    #   sentry-sdk
+    # via -r requirements.in
 six==1.16.0
     # via
     #   awscli-cwlogs


### PR DESCRIPTION
 ## 74.2.0

* Change logging's date formatting to include microseconds

 ## 74.1.0

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/74.0.0...74.2.0



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
