### PR TITLE
show platform on status page

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -41,6 +41,8 @@ class Development(Config):
     DEBUG = True
     NOTIFY_LOG_PATH = "application.log"
 
+    NOTIFY_RUNTIME_PLATFORM = "local"
+
 
 class Test(Development):
     TESTING = True
@@ -52,6 +54,8 @@ class Test(Development):
     API_HOST_NAME = "http://test-notify-api"
     DOCUMENT_DOWNLOAD_API_HOST_NAME = "https://download.test-doc-download-api.gov.uk"
     DOCUMENT_DOWNLOAD_API_HOST_NAME_INTERNAL = "https://download.test-doc-download-api-internal.gov.uk"
+
+    NOTIFY_RUNTIME_PLATFORM = "test"
 
 
 class Preview(Config):

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -33,7 +33,10 @@ FILE_EXTENSION_TO_PRETTY_FILE_TYPE = {
 
 @main.route("/_status")
 def status():
-    return "ok", 200
+    return {
+        "status": "ok",
+        "platform": current_app.config["NOTIFY_RUNTIME_PLATFORM"],
+    }, 200
 
 
 @main.route("/services/_status")

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -15,7 +15,7 @@ from tests import normalize_spaces
 def test_status(client):
     response = client.get(url_for("main.status"))
     assert response.status_code == 200
-    assert response.get_data(as_text=True) == "ok"
+    assert response.json == {"status": "ok", "platform": "test"}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
it's currently set in ecs-service/locals.tf to be "ecs", and we default it to paas otherwise.

we should probs roll out this field to all other apps too in time

locally it now returns

```
{
  "platform": "local",
  "status": "ok"
}
```

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
