### PR TITLE
include onwards request headers in requests to api and document-download-api

### DIFF
--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -1,6 +1,21 @@
 from __future__ import unicode_literals
 
+from flask import request
+from flask.ctx import has_request_context
 from notifications_python_client.notifications import NotificationsAPIClient
+
+
+class OnwardsRequestNotificationsAPIClient(NotificationsAPIClient):
+    def generate_headers(self, api_token):
+        headers = super().generate_headers(api_token)
+
+        if has_request_context() and hasattr(request, "get_onwards_request_headers"):
+            headers = {
+                **request.get_onwards_request_headers(),
+                **headers,
+            }
+
+        return headers
 
 
 class ServiceApiClient:
@@ -8,7 +23,10 @@ class ServiceApiClient:
         self.api_client = None
 
     def init_app(self, application):
-        self.api_client = NotificationsAPIClient(base_url=application.config["API_HOST_NAME"], api_key="a" * 75)
+        self.api_client = OnwardsRequestNotificationsAPIClient(
+            base_url=application.config["API_HOST_NAME"],
+            api_key="a" * 75,
+        )
         self.api_client.service_id = application.config["ADMIN_CLIENT_USER_NAME"]
         self.api_client.api_key = application.config["ADMIN_CLIENT_SECRET"]
 

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -1,3 +1,7 @@
+from unittest import mock
+
+from notifications_utils.testing.comparisons import AnySupersetOf
+
 from app.notify_client.service_api_client import ServiceApiClient
 
 
@@ -7,3 +11,54 @@ def test_client_gets_service(mocker):
 
     client.get_service("foo")
     mock_api_client.get.assert_called_once_with("/service/foo")
+
+
+def test_client_onward_headers(app_, rmock, service_id, sample_service):
+    client = ServiceApiClient()
+    client.init_app(app_)
+
+    rmock.get(
+        "{}/service/{}".format(
+            app_.config["API_HOST_NAME"],
+            service_id,
+        ),
+        status_code=200,
+        json={"data": sample_service},
+    )
+
+    with app_.test_request_context():
+        with mock.patch(
+            "flask.request.get_onwards_request_headers",
+            return_value={
+                "some-onwards": "request-headers",
+                "fooed": "barred",
+            },
+        ):
+            client.get_service(service_id)
+
+    assert len(rmock.request_history) == 1
+    assert rmock.request_history[0].headers == AnySupersetOf(
+        {
+            "some-onwards": "request-headers",
+            "fooed": "barred",
+        }
+    )
+
+
+def test_client_no_onward_headers(app_, rmock, service_id, sample_service):
+    client = ServiceApiClient()
+    client.init_app(app_)
+
+    rmock.get(
+        "{}/service/{}".format(
+            app_.config["API_HOST_NAME"],
+            service_id,
+        ),
+        status_code=200,
+        json={"data": sample_service},
+    )
+
+    # ensure this still works outside a request context
+    client.get_service(service_id)
+
+    assert len(rmock.request_history) == 1


### PR DESCRIPTION
https://trello.com/c/n4FmWuff/585-annotate-logs-with-cloudfront-http-request-ids

These are both a bit of a stopgap until we get proper universal tracing support going. At that point it can be removed.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
