### PR TITLE
Use the internal API host name, rather than the external

### DIFF
--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -9,6 +9,8 @@ class OnwardsRequestNotificationsAPIClient(NotificationsAPIClient):
     def generate_headers(self, api_token):
         headers = super().generate_headers(api_token)
 
+        headers["X-Custom-Forwarder"] = self.route_secret
+
         if has_request_context() and hasattr(request, "get_onwards_request_headers"):
             headers = {
                 **request.get_onwards_request_headers(),
@@ -29,6 +31,7 @@ class ServiceApiClient:
         )
         self.api_client.service_id = application.config["ADMIN_CLIENT_USER_NAME"]
         self.api_client.api_key = application.config["ADMIN_CLIENT_SECRET"]
+        self.api_client.route_secret = application.config["ROUTE_SECRET_KEY_1"]
 
     def get_service(self, service_id):
         """

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -27,7 +27,7 @@ applications:
 
   env:
     ADMIN_CLIENT_SECRET: {{ ADMIN_CLIENT_SECRET }}
-    API_HOST_NAME: {{ API_HOST_NAME }}
+    API_HOST_NAME: {{ API_HOST_NAME_INTERNAL }}
     SECRET_KEY: '{{ DOCUMENT_DOWNLOAD_SECRET_KEY_FRONTEND }}'
     NOTIFY_LOG_PATH: /home/vcap/logs/app.log
 

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -35,6 +35,7 @@ applications:
     FLASK_APP: application.py
     DOCUMENT_DOWNLOAD_API_HOST_NAME: https://download.{{ hostname }}
     DOCUMENT_DOWNLOAD_API_HOST_NAME_INTERNAL: https://download.{{ hostname }}
+    ROUTE_SECRET_KEY_1: '{{ ROUTE_SECRET_KEY_1 }}'
 
     NOTIFY_ENVIRONMENT: {{ environment }}
     AWS_ACCESS_KEY_ID: {{ DOCUMENT_DOWNLOAD_AWS_ACCESS_KEY_ID }}

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -13,6 +13,27 @@ def test_client_gets_service(mocker):
     mock_api_client.get.assert_called_once_with("/service/foo")
 
 
+def test_client_uses_route_secret(app_, rmock, service_id, sample_service):
+    app_.config["ROUTE_SECRET_KEY_1"] = "hello"
+
+    client = ServiceApiClient()
+    client.init_app(app_)
+
+    rmock.get(
+        "{}/service/{}".format(
+            app_.config["API_HOST_NAME"],
+            service_id,
+        ),
+        status_code=200,
+        json={"data": sample_service},
+    )
+
+    client.get_service(service_id)
+
+    assert len(rmock.request_history) == 1
+    assert rmock.request_history[0].headers == AnySupersetOf({"X-Custom-Forwarder": "hello"})
+
+
 def test_client_onward_headers(app_, rmock, service_id, sample_service):
     client = ServiceApiClient()
     client.init_app(app_)
@@ -38,10 +59,7 @@ def test_client_onward_headers(app_, rmock, service_id, sample_service):
 
     assert len(rmock.request_history) == 1
     assert rmock.request_history[0].headers == AnySupersetOf(
-        {
-            "some-onwards": "request-headers",
-            "fooed": "barred",
-        }
+        {"some-onwards": "request-headers", "fooed": "barred", "X-Custom-Forwarder": ""}
     )
 
 


### PR DESCRIPTION
For doc download FE to talk to the API in PaaS, we want it to always use the PaaS route (the internal one). This keeps things consistent with ECS where all inter app requests stay in ECS (so we want all inter app requests in the PaaS to stay in PaaS).

For the moment, this change won't actually do anything because in the credentials repo the API_HOST_NAME_INTERNAL is still set to the external address, but we will shortly change the value to be the PaaS internal address.

This PR Relies on the creation of the internal secret in alphagov/notifications-credentials#417



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
