### PR TITLE
Bump utils to 74.8.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -12,6 +12,6 @@ notifications-python-client==8.0.1
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.6.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.8.0
 govuk-frontend-jinja==2.1.0
 sentry_sdk[flask]>=1.0.0,<2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -84,7 +84,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.6.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.8.0
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils


### PR DESCRIPTION
 ## 74.8.0

* NotifyRequest: generate own span_id if none provided in headers

 ## 74.7.0

* Include onwards request headers in AntivirusClient requests

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/74.6.0...74.8.0



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
