### PR TITLE
Use PaaS domain for doc download API internally

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -34,7 +34,7 @@ applications:
     NOTIFY_APP_NAME: document-download-frontend
     FLASK_APP: application.py
     DOCUMENT_DOWNLOAD_API_HOST_NAME: https://download.{{ hostname }}
-    DOCUMENT_DOWNLOAD_API_HOST_NAME_INTERNAL: https://download.{{ hostname }}
+    DOCUMENT_DOWNLOAD_API_HOST_NAME_INTERNAL: https://document-download-api-{{ environment}}.cloudapps.digital
     ROUTE_SECRET_KEY_1: '{{ ROUTE_SECRET_KEY_1 }}'
 
     NOTIFY_ENVIRONMENT: {{ environment }}


### PR DESCRIPTION
We want PaaS inter app requests to stay on the Paas, rather than going to cloudfront. This enables the PaaS to stay distinct from ECS and mimics equivalent changes to the other apps.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
