### PR TITLE
Bump govuk frontend to 4.7.0

### DIFF
--- a/app/assets/javascripts/govuk-frontend-local.mjs
+++ b/app/assets/javascripts/govuk-frontend-local.mjs
@@ -23,30 +23,32 @@ function nodeListForEach (nodes, callback) {
   }
 }
 
-// Copy of the initAll function from https://github.com/alphagov/govuk-frontend/blob/v3.5.0/src/govuk/all.js
+// Copy of the initAll function from https://github.com/alphagov/govuk-frontend/blob/v4.7.0/package/govuk-esm/common/index.mjs
 // except it only includes, and initialises, the components used by this application.
-function initAll (options) {
-  // Set the options to an empty object by default if no options are passed.
-  options = typeof options !== 'undefined' ? options : {}
+function initAll (config) {
+  // Set the config to an empty object by default if no config are passed.
+  config = typeof config !== 'undefined' ? config : {}
 
   // Allow the user to initialise GOV.UK Frontend in only certain sections of the page
   // Defaults to the entire document if nothing is set.
-  var scope = typeof options.scope !== 'undefined' ? options.scope : document
+  var $scope = config.scope instanceof HTMLElement ? config.scope : document;
 
-  // Find all buttons with [role=button] on the scope to enhance.
-  var buttons = scope.querySelectorAll('[data-module="govuk-button"]')
-  nodeListForEach(buttons, function (button) {
-    new Button(button).init()
-  });
+  var $buttons = $scope.querySelectorAll('[data-module="govuk-button"]')
+  nodeListForEach($buttons, function ($button) {
+    new Button($button, config.button).init()
+  })
 
   // Find first error summary module to enhance.
-  var $errorSummary = scope.querySelector('[data-module="govuk-error-summary"]')
-  new ErrorSummary($errorSummary).init()
+  var $errorSummary = $scope.querySelector('[data-module="govuk-error-summary"]')
+  if ($errorSummary) {
+    new ErrorSummary($errorSummary, config.errorSummary).init()
+  }
 
-  // There will only ever be one skip-link per page
-  var skipLink = scope.querySelector('[data-module="govuk-skip-link"]')
-
-  new SkipLink(skipLink).init()
+  // Find first skip link module to enhance.
+  var $skipLink = $scope.querySelector('[data-module="govuk-skip-link"]')
+  if ($skipLink) {
+    new SkipLink($skipLink).init()
+  }
 }
 
 var Frontend = {

--- a/app/assets/stylesheets/main-ie8.scss
+++ b/app/assets/stylesheets/main-ie8.scss
@@ -1,3 +1,0 @@
-$govuk-is-ie8: true;
-
-@import 'main';

--- a/app/templates/document_download_template.html
+++ b/app/templates/document_download_template.html
@@ -11,18 +11,10 @@
 {% endblock %}
 
 {% block head %}
-  <!--[if !IE 8]><!-->
-    <link rel="stylesheet" media="screen" href="{{ asset_url('stylesheets/main.css') }}" />
-  <!--<![endif]-->
-  <!--[if IE 8]>
-    <link rel="stylesheet" media="screen" href="{{ asset_url('stylesheets/main-ie8.css') }}">
-  <![endif]-->
+  <link rel="stylesheet" media="screen" href="{{ asset_url('stylesheets/main.css') }}" />
   <style>
       .govuk-header__container { border-bottom-color: {{header_colour}} }
   </style>
-  <!--[if lt IE 9]>
-    <script src="{{ asset_url('javascripts/html5shiv.min.js') }}"></script>
-  <![endif]-->
   {% block meta %}
   <meta name="referrer" content="never">
   {% endblock %}
@@ -57,7 +49,5 @@
 {% endblock %}
 
 {% block bodyEnd %}
-  <!--[if gt IE 8]><!-->
   <script type="text/javascript" src="{{ asset_url('javascripts/main.js') }}"></script>
-  <!--<![endif]-->
 {% endblock %}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,7 +5,7 @@
 
 // 1. LIBRARIES
 // - - - - - - - - - - - - - - -
-const { src, pipe, dest, series, parallel } = require('gulp');
+const { src, pipe, dest, series, parallel, watch } = require('gulp');
 const oldie = require('oldie');
 const postcss = require('gulp-postcss');
 const rollup = require('rollup');
@@ -113,7 +113,10 @@ const images = () => {
 
 // Watch for changes and re-run tasks
 const watchForChanges = () => {
-  return watch(paths.src + 'stylesheets/**/*', ['sass'])
+  return watch(paths.src + 'stylesheets/**/*', parallel(
+    sass,
+    javascripts
+  ))
 };
 
 const lint = {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -47,10 +47,6 @@ const copy = {
       return src(paths.govuk_frontend + 'assets/fonts/**/*')
         .pipe(dest(paths.dist + 'fonts/'));
     }
-  },
-  js: () => {
-    return src(paths.src + 'javascripts/html5shiv.min.js')
-      .pipe(dest(paths.dist + 'javascripts/'));
   }
 };
 
@@ -78,7 +74,7 @@ const javascripts = () => {
         include: 'node_modules/**'
       }),
       // Terser is a replacement for UglifyJS
-      rollupPluginTerser({'ie8': true})
+      rollupPluginTerser()
     ]
   }).then(bundle => {
     return bundle.write({
@@ -101,20 +97,6 @@ const sass = () => {
         paths.govuk_frontend
       ]
     }))
-    .pipe(dest(paths.dist + 'stylesheets/'))
-};
-
-
-const ieSass = () => {
-  return src(paths.src + '/stylesheets/main-ie*.scss')
-    .pipe(plugins.prettyerror())
-    .pipe(plugins.sass({
-      outputStyle: 'compressed',
-      includePaths: [
-        paths.govuk_frontend
-      ]
-    }))
-    .pipe(postcss(oldie))
     .pipe(dest(paths.dist + 'stylesheets/'))
 };
 
@@ -163,13 +145,9 @@ const defaultTask = parallel(
   series(
     parallel(
       copy.govuk_frontend.fonts,
-      copy.js,
       images
     ),
-    parallel(
-      sass,
-      ieSass
-    )
+    sass
   ),
   javascripts
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "govuk-frontend": "4.5.0"
+        "govuk-frontend": "4.7.0"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "21.0.1",
@@ -2586,9 +2586,9 @@
       "license": "MIT"
     },
     "node_modules/govuk-frontend": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.5.0.tgz",
-      "integrity": "sha512-gZHDqf5vdlHjmx0NGJiNT12XLyR3d5KCS4AnlC3xTWOObJ0kQROrkIFyp3w4/PY3EQiYdgacVaJ6lizzygnzYw==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.7.0.tgz",
+      "integrity": "sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg==",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -8959,9 +8959,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.5.0.tgz",
-      "integrity": "sha512-gZHDqf5vdlHjmx0NGJiNT12XLyR3d5KCS4AnlC3xTWOObJ0kQROrkIFyp3w4/PY3EQiYdgacVaJ6lizzygnzYw=="
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.7.0.tgz",
+      "integrity": "sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg=="
     },
     "graceful-fs": {
       "version": "4.2.8",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": "Government Digital Service",
   "license": "MIT",
   "dependencies": {
-    "govuk-frontend": "4.5.0"
+    "govuk-frontend": "4.7.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "21.0.1",

--- a/requirements.in
+++ b/requirements.in
@@ -13,5 +13,5 @@ notifications-python-client==8.0.1
 awscli-cwlogs>=1.4,<1.5
 
 notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.8.0
-govuk-frontend-jinja==2.1.0
+govuk-frontend-jinja==2.7.0
 sentry_sdk[flask]>=1.0.0,<2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,7 @@ flask-wtf==1.2.1
     # via -r requirements.in
 govuk-bank-holidays==0.10
     # via notifications-utils
-govuk-frontend-jinja==2.1.0
+govuk-frontend-jinja==2.7.0
     # via -r requirements.in
 greenlet==3.0.3
     # via eventlet


### PR DESCRIPTION
Bumps the version of GOVUK Frontend (the library for the GOVUK Design System) to v4.7.0.

Also brings in v2.7.0 of [GOVUK Frontend Jinja](https://github.com/LandRegistry/govuk-frontend-jinja), to render the HTML.

## Notes for reviewers

This has been tested in [all the browsers we support](https://github.com/alphagov/notifications-manuals/wiki/Support-for-browsers,-email-clients-and-assistive-technologies#browsers).

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
