### PR TITLE
Change crown logo to tudor crown

### DIFF
--- a/app/templates/document_download_template.html
+++ b/app/templates/document_download_template.html
@@ -31,7 +31,8 @@
 {% block header %}
   {{ govukHeader({
     "assetsPath": "/static/images/",
-    "homepageUrl": "https://www.gov.uk"
+    "homepageUrl": "https://www.gov.uk",
+    "useTudorCrown": True,
   }) }}
 {% endblock %}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "govuk-frontend": "4.7.0"
+        "govuk-frontend": "4.8.0"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "21.0.1",
@@ -2586,9 +2586,9 @@
       "license": "MIT"
     },
     "node_modules/govuk-frontend": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.7.0.tgz",
-      "integrity": "sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.8.0.tgz",
+      "integrity": "sha512-NOmPJxL8IYq1HSNHYKx9XY2LLTxuwb+IFASiGQO4sgJ8K7AG66SlSeqARrcetevV8zOf+i1z+MbJJ2O7//OxAw==",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -8959,9 +8959,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.7.0.tgz",
-      "integrity": "sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg=="
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.8.0.tgz",
+      "integrity": "sha512-NOmPJxL8IYq1HSNHYKx9XY2LLTxuwb+IFASiGQO4sgJ8K7AG66SlSeqARrcetevV8zOf+i1z+MbJJ2O7//OxAw=="
     },
     "graceful-fs": {
       "version": "4.2.8",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": "Government Digital Service",
   "license": "MIT",
   "dependencies": {
-    "govuk-frontend": "4.7.0"
+    "govuk-frontend": "4.8.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "21.0.1",

--- a/requirements.in
+++ b/requirements.in
@@ -13,5 +13,5 @@ notifications-python-client==8.0.1
 awscli-cwlogs>=1.4,<1.5
 
 notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.8.0
-govuk-frontend-jinja==2.7.0
+govuk-frontend-jinja==2.8.0
 sentry_sdk[flask]>=1.0.0,<2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,14 +52,12 @@ flask-wtf==1.2.1
     # via -r requirements.in
 govuk-bank-holidays==0.10
     # via notifications-utils
-govuk-frontend-jinja==2.7.0
+govuk-frontend-jinja==2.8.0
     # via -r requirements.in
 greenlet==3.0.3
     # via eventlet
 gunicorn[eventlet]==21.2.0
-    # via
-    #   -r requirements.in
-    #   gunicorn
+    # via -r requirements.in
 idna==3.3
     # via requests
 itsdangerous==2.1.2
@@ -129,9 +127,7 @@ s3transfer==0.6.1
 segno==1.5.2
     # via notifications-utils
 sentry-sdk[flask]==1.32.0
-    # via
-    #   -r requirements.in
-    #   sentry-sdk
+    # via -r requirements.in
 six==1.16.0
     # via
     #   awscli-cwlogs


### PR DESCRIPTION
Changes the crown used in the header, favicon and other places to be the tudor crown.

## Before

<img width="987" alt="image" src="https://github.com/alphagov/document-download-frontend/assets/87140/7f123402-b77b-49ed-b8b3-d93a3badd07e">

## After

<img width="987" alt="image" src="https://github.com/alphagov/document-download-frontend/assets/87140/81b64ecf-811a-4638-8a94-65af454581f5">

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
