### PR TITLE
Add note about restarting app after asset changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ in a separate terminal from the app
 npm run watch
 ```
 
+You will need to restart the app after any changes to front end assets, so that they are served with
+the correct `Content-Length` header for their contents. If you are using
+[notifications-local](https://github.com/alphagov/notifications-local), you will need to run:
+
+```bash
+docker compose restart document-download-frontend
+```
+
 ### Updating the Node version for frontend builds
 
 Edit the respective `node` version specified in the `.nvmrc` file.


### PR DESCRIPTION
Whitenoise doesn't seem to pick up changes to static assets automatically and so can end up serving them with the wrong content length after changes.

This adds a note to remind about the need to restart the app, to give whitenoise a kick.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
