### PR TITLE
Bump utils to 7.11.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -12,6 +12,6 @@ notifications-python-client==8.0.1
 # PaaS
 awscli-cwlogs>=1.4,<1.5
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.8.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.11.0
 govuk-frontend-jinja==2.7.0
 sentry_sdk[flask]>=1.0.0,<2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -86,7 +86,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.8.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.11.0
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils


### PR DESCRIPTION
Bump utils to 7.11.0

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
