### PR TITLE
remove use of `NOTIFY_RUNTIME_PLATFORM` & `NOTIFY_LOG_PATH` flask config parameters

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -24,9 +24,6 @@ class Config(object):
 
     ROUTE_SECRET_KEY_1 = os.environ.get("ROUTE_SECRET_KEY_1", "")
 
-    # needs to refer to notify for utils
-    NOTIFY_LOG_PATH = os.getenv("NOTIFY_LOG_PATH")
-
 
 class Development(Config):
     SERVER_NAME = os.getenv("SERVER_NAME")
@@ -40,7 +37,6 @@ class Development(Config):
     SECRET_KEY = "dev-notify-secret-key"
 
     DEBUG = True
-    NOTIFY_LOG_PATH = "application.log"
 
 
 class Test(Development):

--- a/app/config.py
+++ b/app/config.py
@@ -8,7 +8,6 @@ class Config(object):
     SECRET_KEY = os.environ.get("SECRET_KEY")
 
     API_HOST_NAME = os.environ.get("API_HOST_NAME")
-    NOTIFY_RUNTIME_PLATFORM = os.environ.get("NOTIFY_RUNTIME_PLATFORM", "ecs")
 
     CHECK_PROXY_HEADER = False
 
@@ -43,8 +42,6 @@ class Development(Config):
     DEBUG = True
     NOTIFY_LOG_PATH = "application.log"
 
-    NOTIFY_RUNTIME_PLATFORM = "local"
-
 
 class Test(Development):
     TESTING = True
@@ -56,8 +53,6 @@ class Test(Development):
     API_HOST_NAME = "http://test-notify-api"
     DOCUMENT_DOWNLOAD_API_HOST_NAME = "https://download.test-doc-download-api.gov.uk"
     DOCUMENT_DOWNLOAD_API_HOST_NAME_INTERNAL = "https://download.test-doc-download-api-internal.gov.uk"
-
-    NOTIFY_RUNTIME_PLATFORM = "test"
 
 
 class Preview(Config):

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -36,7 +36,6 @@ FILE_EXTENSION_TO_PRETTY_FILE_TYPE = {
 def status():
     return {
         "status": "ok",
-        "platform": current_app.config["NOTIFY_RUNTIME_PLATFORM"],
     }, 200
 
 

--- a/requirements.in
+++ b/requirements.in
@@ -9,6 +9,6 @@ whitenoise==6.2.0  #manages static assets
 
 notifications-python-client==8.0.1
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@75.1.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@76.0.0
 govuk-frontend-jinja==2.8.0
 sentry_sdk[flask]>=1.0.0,<2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -77,7 +77,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@75.1.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@76.0.0
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -16,7 +16,7 @@ from tests import normalize_spaces
 def test_status(client):
     response = client.get(url_for("main.status"))
     assert response.status_code == 200
-    assert response.json == {"status": "ok", "platform": "test"}
+    assert response.json == {"status": "ok"}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
https://trello.com/c/kuPbusFR/724-check-if-we-should-and-then-remove-notifyruntimeplatform-functionality

~Depends on https://github.com/alphagov/notifications-utils/pull/1109 (though actually doesn't technically require it)~

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
