### PR TITLE
Revert "gunicorn structured logging"

### DIFF
--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -1,9 +1,11 @@
-from notifications_utils.gunicorn_defaults import set_gunicorn_defaults
+import os
 
-set_gunicorn_defaults(globals())
-
+import gunicorn
 
 workers = 10
 worker_class = "eventlet"
 worker_connections = 1000
+bind = "0.0.0.0:{}".format(os.getenv("PORT"))
+errorlog = "/home/vcap/logs/gunicorn_error.log"
+gunicorn.SERVER_SOFTWARE = "None"
 keepalive = 90

--- a/requirements.in
+++ b/requirements.in
@@ -9,6 +9,6 @@ whitenoise==6.2.0  #manages static assets
 
 notifications-python-client==8.0.1
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@75.1.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.11.0
 govuk-frontend-jinja==2.8.0
 sentry_sdk[flask]>=1.0.0,<2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,9 +48,7 @@ govuk-frontend-jinja==2.8.0
 greenlet==3.0.3
     # via eventlet
 gunicorn[eventlet]==21.2.0
-    # via
-    #   -r requirements.in
-    #   notifications-utils
+    # via -r requirements.in
 idna==3.3
     # via requests
 itsdangerous==2.1.2
@@ -77,7 +75,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@75.1.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.11.0
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils
@@ -109,7 +107,9 @@ s3transfer==0.6.1
 segno==1.5.2
     # via notifications-utils
 sentry-sdk[flask]==1.32.0
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   sentry-sdk
 six==1.16.0
     # via
     #   eventlet


### PR DESCRIPTION
Reverts alphagov/document-download-frontend#223

Ugh statsd shouldn't be enabled for this app and the statsd config got included in the common gunicorn configuration