### PR TITLE
Stop passing proxy header when calling api

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -9,8 +9,6 @@ class Config(object):
 
     API_HOST_NAME = os.environ.get("API_HOST_NAME")
 
-    CHECK_PROXY_HEADER = False
-
     # Logging
     DEBUG = False
 
@@ -21,8 +19,6 @@ class Config(object):
 
     HEADER_COLOUR = "#FFBF47"  # $yellow
     HTTP_PROTOCOL = "http"
-
-    ROUTE_SECRET_KEY_1 = os.environ.get("ROUTE_SECRET_KEY_1", "")
 
 
 class Development(Config):

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -9,8 +9,6 @@ class OnwardsRequestNotificationsAPIClient(NotificationsAPIClient):
     def generate_headers(self, api_token):
         headers = super().generate_headers(api_token)
 
-        headers["X-Custom-Forwarder"] = self.route_secret
-
         if has_request_context() and hasattr(request, "get_onwards_request_headers"):
             headers = {
                 **request.get_onwards_request_headers(),
@@ -31,7 +29,6 @@ class ServiceApiClient:
         )
         self.api_client.service_id = application.config["ADMIN_CLIENT_USER_NAME"]
         self.api_client.api_key = application.config["ADMIN_CLIENT_SECRET"]
-        self.api_client.route_secret = application.config["ROUTE_SECRET_KEY_1"]
 
     def get_service(self, service_id):
         """

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -13,27 +13,6 @@ def test_client_gets_service(mocker):
     mock_api_client.get.assert_called_once_with("/service/foo")
 
 
-def test_client_uses_route_secret(app_, rmock, service_id, sample_service):
-    app_.config["ROUTE_SECRET_KEY_1"] = "hello"
-
-    client = ServiceApiClient()
-    client.init_app(app_)
-
-    rmock.get(
-        "{}/service/{}".format(
-            app_.config["API_HOST_NAME"],
-            service_id,
-        ),
-        status_code=200,
-        json={"data": sample_service},
-    )
-
-    client.get_service(service_id)
-
-    assert len(rmock.request_history) == 1
-    assert rmock.request_history[0].headers == AnySupersetOf({"X-Custom-Forwarder": "hello"})
-
-
 def test_client_onward_headers(app_, rmock, service_id, sample_service):
     client = ServiceApiClient()
     client.init_app(app_)
@@ -58,9 +37,7 @@ def test_client_onward_headers(app_, rmock, service_id, sample_service):
             client.get_service(service_id)
 
     assert len(rmock.request_history) == 1
-    assert rmock.request_history[0].headers == AnySupersetOf(
-        {"some-onwards": "request-headers", "fooed": "barred", "X-Custom-Forwarder": ""}
-    )
+    assert rmock.request_history[0].headers == AnySupersetOf({"some-onwards": "request-headers", "fooed": "barred"})
 
 
 def test_client_no_onward_headers(app_, rmock, service_id, sample_service):


### PR DESCRIPTION
This reverts the changes added in 058fa4f4c6f6325f23dcb4419e920d091cbd4b05 to add the proxy header to requests made to the api. This is not needed now that we have migrated to ECS. It also removes `CHECK_PROXY_HEADER` from the Config.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
