### PR TITLE
Remove environment knowledge from application

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -9,7 +9,7 @@ from notifications_utils.clients.statsd.statsd_client import StatsdClient
 from werkzeug.routing import BaseConverter, ValidationError
 
 from app.asset_fingerprinter import AssetFingerprinter
-from app.config import configs
+from app.config import Config, configs
 from app.notify_client.service_api_client import ServiceApiClient
 
 statsd_client = StatsdClient()
@@ -32,7 +32,11 @@ class Base64UUIDConverter(BaseConverter):
 
 
 def create_app(application):
-    application.config.from_object(configs[os.environ["NOTIFY_ENVIRONMENT"]])
+    notify_environment = os.environ["NOTIFY_ENVIRONMENT"]
+    if notify_environment in configs:
+        application.config.from_object(configs[notify_environment])
+    else:
+        application.config.from_object(Config)
 
     application.url_map.converters["base64_uuid"] = Base64UUIDConverter
 

--- a/app/config.py
+++ b/app/config.py
@@ -16,8 +16,8 @@ class Config(object):
     DOCUMENT_DOWNLOAD_API_HOST_NAME = os.environ.get("DOCUMENT_DOWNLOAD_API_HOST_NAME")
     DOCUMENT_DOWNLOAD_API_HOST_NAME_INTERNAL = os.environ.get("DOCUMENT_DOWNLOAD_API_HOST_NAME_INTERNAL")
 
-    HEADER_COLOUR = "#FFBF47"  # $yellow
-    HTTP_PROTOCOL = "http"
+    HEADER_COLOUR = os.environ.get("HEADER_COLOUR", "#FFBF47")  # $yellow
+    HTTP_PROTOCOL = os.environ.get("HTTP_PROTOCOL", "http")
 
 
 class Development(Config):
@@ -46,25 +46,7 @@ class Test(Development):
     DOCUMENT_DOWNLOAD_API_HOST_NAME_INTERNAL = "https://download.test-doc-download-api-internal.gov.uk"
 
 
-class Preview(Config):
-    HTTP_PROTOCOL = "https"
-    HEADER_COLOUR = "#F499BE"  # $baby-pink
-
-
-class Staging(Config):
-    HTTP_PROTOCOL = "https"
-    HEADER_COLOUR = "#6F72AF"  # $mauve
-
-
-class Production(Config):
-    HEADER_COLOUR = "#005EA5"  # $govuk-blue
-    HTTP_PROTOCOL = "https"
-
-
 configs = {
     "development": Development,
     "test": Test,
-    "preview": Preview,
-    "staging": Staging,
-    "production": Production,
 }

--- a/app/performance.py
+++ b/app/performance.py
@@ -11,7 +11,7 @@ def sentry_sampler(sampling_context, sample_rate: float = 0.0):
 
 def init_performance_monitoring():
     environment = os.getenv("NOTIFY_ENVIRONMENT").lower()
-    not_production = environment in {"development", "preview", "staging"}
+    allow_pii = os.getenv("SENTRY_ALLOW_PII", "0") == "1"
     sentry_enabled = bool(int(os.getenv("SENTRY_ENABLED", "0")))
     sentry_dsn = os.getenv("SENTRY_DSN")
 
@@ -21,8 +21,8 @@ def init_performance_monitoring():
         error_sample_rate = float(os.getenv("SENTRY_ERRORS_SAMPLE_RATE", 0.0))
         trace_sample_rate = float(os.getenv("SENTRY_TRACES_SAMPLE_RATE", 0.0))
 
-        send_pii = True if not_production else False
-        send_request_bodies = "medium" if not_production else "never"
+        send_pii = True if allow_pii else False
+        send_request_bodies = "medium" if allow_pii else "never"
 
         traces_sampler = partial(sentry_sampler, sample_rate=trace_sample_rate)
 


### PR DESCRIPTION
What
----

Remove environment knowledge from application. Environment configuration will be passed in during deployments.

Replace environment name checks with feature flags.

Why
----

We are updating our notify deployment model to allow for many more environments. As such environment settings will be kept in as few places as possible (eventually just one place).

The main benefit of this is to be able to add new environments without having to modify source code

Note
----

This change should not be merged until the deployment configuration has been updated. See [the following pr](https://github.com/alphagov/notifications-aws/pull/2208)

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
