### PR TITLE
bump utils to 78.0.0 (recipient_validation refactor)

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -2,7 +2,8 @@ from flask import render_template
 from flask_wtf import FlaskForm as Form
 from markupsafe import Markup
 from notifications_utils.formatters import strip_all_whitespace
-from notifications_utils.recipients import InvalidEmailError, validate_email_address
+from notifications_utils.recipient_validation.email_address import validate_email_address
+from notifications_utils.recipient_validation.errors import InvalidEmailError
 from wtforms import StringField, ValidationError
 from wtforms.validators import DataRequired
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -2,7 +2,7 @@ import re
 from datetime import date
 
 from dateutil import parser
-from notifications_utils.recipients import EMAIL_REGEX_PATTERN
+from notifications_utils.recipient_validation.email_address import EMAIL_REGEX_PATTERN
 
 
 def assess_contact_type(service_contact_info):

--- a/requirements.in
+++ b/requirements.in
@@ -9,6 +9,6 @@ whitenoise==6.2.0  #manages static assets
 
 notifications-python-client==8.0.1
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@77.1.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@78.0.0
 govuk-frontend-jinja==2.8.0
 sentry_sdk[flask]>=1.0.0,<2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -77,7 +77,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@77.1.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@78.0.0
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils
@@ -109,7 +109,9 @@ s3transfer==0.6.1
 segno==1.5.2
     # via notifications-utils
 sentry-sdk[flask]==1.32.0
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   sentry-sdk
 six==1.16.0
     # via python-dateutil
 smartypants==2.0.1


### PR DESCRIPTION

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
