### PR TITLE
Bump utils to 79.0.0

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -22,13 +22,13 @@ class Base64UUIDConverter(BaseConverter):
         try:
             return base64_to_uuid(value)
         except ValueError as e:
-            raise ValidationError() from e
+            raise ValidationError from e
 
     def to_url(self, value):
         try:
             return uuid_to_base64(value)
         except Exception as e:
-            raise ValidationError() from e
+            raise ValidationError from e
 
 
 def create_app(application):

--- a/app/asset_fingerprinter.py
+++ b/app/asset_fingerprinter.py
@@ -1,7 +1,7 @@
 import hashlib
 
 
-class AssetFingerprinter(object):
+class AssetFingerprinter:
     """
     Get a unique hash for an asset file, so that it doesn't stay cached
     when it changes

--- a/app/config.py
+++ b/app/config.py
@@ -1,7 +1,7 @@
 import os
 
 
-class Config(object):
+class Config:
     ADMIN_CLIENT_SECRET = os.environ.get("ADMIN_CLIENT_SECRET")
     ADMIN_CLIENT_USER_NAME = "notify-admin"
     SECRET_KEY = os.environ.get("SECRET_KEY")

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -1,5 +1,4 @@
 from datetime import date, timedelta
-from typing import Optional
 from urllib import parse
 
 import requests
@@ -255,7 +254,7 @@ def _get_document_metadata(service_id, document_id, key):
     return response.json().get("document")
 
 
-def _authenticate_access_to_document(service_id, document_id, key, email_address) -> Optional[dict]:
+def _authenticate_access_to_document(service_id, document_id, key, email_address) -> dict | None:
     auth_file_url = "{}/services/{}/documents/{}/authenticate".format(
         current_app.config["DOCUMENT_DOWNLOAD_API_HOST_NAME_INTERNAL"],
         service_id,

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -83,7 +83,7 @@ def landing(service_id, document_id):
     if "confirm_email" not in metadata:
         current_app.logger.info(
             "Metadata for %(service_id)s/%(document_id)s does not contain `confirm_email` key: %(metadata)s",
-            dict(service_id=service_id, document_id=document_id, metadata=metadata),
+            {"service_id": service_id, "document_id": document_id, "metadata": metadata},
         )
 
     if metadata.get("confirm_email", False) is True:
@@ -271,7 +271,7 @@ def _authenticate_access_to_document(service_id, document_id, key, email_address
     )
 
     if response.status_code == 429:
-        raise TooManyRequests()
+        raise TooManyRequests
 
     elif response.status_code in {400, 403}:
         return None

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -1,4 +1,3 @@
-
 from flask import request
 from flask.ctx import has_request_context
 from notifications_python_client.notifications import NotificationsAPIClient

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 
 from flask import request
 from flask.ctx import has_request_context
@@ -34,4 +33,4 @@ class ServiceApiClient:
         """
         Retrieve a service.
         """
-        return self.api_client.get("/service/{0}".format(service_id))
+        return self.api_client.get(f"/service/{service_id}")

--- a/requirements.in
+++ b/requirements.in
@@ -9,6 +9,6 @@ whitenoise==6.2.0  #manages static assets
 
 notifications-python-client==8.0.1
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@78.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@79.0.0
 govuk-frontend-jinja==2.8.0
 sentry_sdk[flask]>=1.0.0,<2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,13 +8,13 @@ blinker==1.6.2
     # via
     #   flask
     #   sentry-sdk
-boto3==1.28.5
+boto3==1.34.129
     # via notifications-utils
-botocore==1.31.5
+botocore==1.34.129
     # via
     #   boto3
     #   s3transfer
-cachetools==4.2.4
+cachetools==5.3.3
     # via notifications-utils
 certifi==2023.7.22
     # via
@@ -41,7 +41,7 @@ flask-redis==0.4.0
     # via notifications-utils
 flask-wtf==1.2.1
     # via -r requirements.in
-govuk-bank-holidays==0.10
+govuk-bank-holidays==0.14
     # via notifications-utils
 govuk-frontend-jinja==2.8.0
     # via -r requirements.in
@@ -77,7 +77,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@78.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@79.0.0
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils
@@ -91,9 +91,9 @@ pypdf==3.17.0
     # via notifications-utils
 python-dateutil==2.8.2
     # via botocore
-python-json-logger==2.0.2
+python-json-logger==2.0.7
     # via notifications-utils
-pytz==2021.3
+pytz==2024.1
     # via notifications-utils
 pyyaml==6.0.1
     # via notifications-utils
@@ -104,19 +104,17 @@ requests==2.32.0
     #   govuk-bank-holidays
     #   notifications-python-client
     #   notifications-utils
-s3transfer==0.6.1
+s3transfer==0.10.1
     # via boto3
 segno==1.5.2
     # via notifications-utils
 sentry-sdk[flask]==1.32.0
-    # via
-    #   -r requirements.in
-    #   sentry-sdk
+    # via -r requirements.in
 six==1.16.0
     # via python-dateutil
 smartypants==2.0.1
     # via notifications-utils
-statsd==3.3.0
+statsd==4.0.1
     # via notifications-utils
 urllib3==1.26.18
     # via

--- a/tests/app/test_asset_fingerprinter.py
+++ b/tests/app/test_asset_fingerprinter.py
@@ -1,18 +1,15 @@
-# coding=utf-8
 
 from app.asset_fingerprinter import AssetFingerprinter
 
 
-class TestAssetFingerprint(object):
+class TestAssetFingerprint:
     def test_url_format(self, mocker):
         get_file_content_mock = mocker.patch.object(AssetFingerprinter, "get_asset_file_contents")
-        get_file_content_mock.return_value = """
+        get_file_content_mock.return_value = b"""
             body {
                 font-family: nta;
             }
-        """.encode(
-            "utf-8"
-        )
+        """
         asset_fingerprinter = AssetFingerprinter(asset_root="/suppliers/static/")
         assert (
             asset_fingerprinter.get_url("application.css")
@@ -25,24 +22,20 @@ class TestAssetFingerprint(object):
 
     def test_building_file_path(self, mocker):
         get_file_content_mock = mocker.patch.object(AssetFingerprinter, "get_asset_file_contents")
-        get_file_content_mock.return_value = """
+        get_file_content_mock.return_value = b"""
             document.write('Hello world!');
-        """.encode(
-            "utf-8"
-        )
+        """
         fingerprinter = AssetFingerprinter()
         fingerprinter.get_url("javascripts/application.js")
         fingerprinter.get_asset_file_contents.assert_called_with("app/static/javascripts/application.js")
 
     def test_hashes_are_consistent(self, mocker):
         get_file_content_mock = mocker.patch.object(AssetFingerprinter, "get_asset_file_contents")
-        get_file_content_mock.return_value = """
+        get_file_content_mock.return_value = b"""
             body {
                 font-family: nta;
             }
-        """.encode(
-            "utf-8"
-        )
+        """
         asset_fingerprinter = AssetFingerprinter()
         assert asset_fingerprinter.get_asset_fingerprint(
             "application.css"
@@ -51,31 +44,25 @@ class TestAssetFingerprint(object):
     def test_hashes_are_different_for_different_files(self, mocker):
         get_file_content_mock = mocker.patch.object(AssetFingerprinter, "get_asset_file_contents")
         asset_fingerprinter = AssetFingerprinter()
-        get_file_content_mock.return_value = """
+        get_file_content_mock.return_value = b"""
             body {
                 font-family: nta;
             }
-        """.encode(
-            "utf-8"
-        )
+        """
         css_hash = asset_fingerprinter.get_asset_fingerprint("application.css")
-        get_file_content_mock.return_value = """
+        get_file_content_mock.return_value = b"""
             document.write('Hello world!');
-        """.encode(
-            "utf-8"
-        )
+        """
         js_hash = asset_fingerprinter.get_asset_fingerprint("application.js")
         assert js_hash != css_hash
 
     def test_hash_gets_cached(self, mocker):
         get_file_content_mock = mocker.patch.object(AssetFingerprinter, "get_asset_file_contents")
-        get_file_content_mock.return_value = """
+        get_file_content_mock.return_value = b"""
             body {
                 font-family: nta;
             }
-        """.encode(
-            "utf-8"
-        )
+        """
         fingerprinter = AssetFingerprinter()
         assert fingerprinter.get_url("application.css") == "/static/application.css?418e6f4a6cdf1142e45c072ed3e1c90a"
         fingerprinter._cache["application.css"] = "a1a1a1"
@@ -83,7 +70,7 @@ class TestAssetFingerprint(object):
         fingerprinter.get_asset_file_contents.assert_called_once_with("app/static/application.css")
 
 
-class TestAssetFingerprintWithUnicode(object):
+class TestAssetFingerprintWithUnicode:
     def test_can_read_self(self):
         "Ralph’s apostrophe is a string containing a unicode character"
         AssetFingerprinter(filesystem_path="tests/app/").get_url("test_asset_fingerprinter.py")

--- a/tests/app/test_asset_fingerprinter.py
+++ b/tests/app/test_asset_fingerprinter.py
@@ -1,4 +1,3 @@
-
 from app.asset_fingerprinter import AssetFingerprinter
 
 


### PR DESCRIPTION
 ## 79.0.0

* Switches on Pyupgrade and a bunch of other more opinionated linting rules

 ## 78.2.0

* Bumped minimum versions of select subdependencies

 ## 78.1.0

* Restrict postcodes to valid UK postcode zones

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/78.0.0...79.0.0

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
