### PR TITLE
Remove subdependencies from requirements.in

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,6 @@
 # Run `make freeze-requirements` to update requirements.txt
 # with package version changes made in requirements-app.txt
 
-Flask==3.0.0
 Flask-WTF==1.2.1
 
 gunicorn[eventlet]>=21.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,6 @@ eventlet==0.35.2
     # via gunicorn
 flask==3.0.0
     # via
-    #   -r requirements.in
     #   flask-redis
     #   flask-wtf
     #   notifications-utils
@@ -109,9 +108,7 @@ s3transfer==0.6.1
 segno==1.5.2
     # via notifications-utils
 sentry-sdk[flask]==1.32.0
-    # via
-    #   -r requirements.in
-    #   sentry-sdk
+    # via -r requirements.in
 six==1.16.0
     # via python-dateutil
 smartypants==2.0.1


### PR DESCRIPTION
If a dependency is already:
- specified as a subdependency of one of our other dependencies
- spcified in the dependencies of `notifications-utils`

…then we don’t need to also specify it in `requirements.in`, unless we are trying to pin it to a specific version



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
