### PR TITLE
Dockerfile: pre-compile bytecode for app in production image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -61,7 +61,8 @@ COPY --from=frontend-build /usr/frontend/app/static app/static
 COPY --from=frontend-build /usr/frontend/app/templates app/templates
 COPY --from=python_build --chown=notify:notify /home/vcap/app/app/version.py app/version.py
 USER root
-RUN chown -R notify:notify /home/vcap/app && \
+RUN python -m compileall . && \
+    chown -R notify:notify /home/vcap/app && \
     chmod +x /home/vcap/app/entrypoint.sh
 USER notify
 


### PR DESCRIPTION
This should produce a small improvement in startup time. Bytecode for the libraries in the venv is already generated during pip install.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
