### PR TITLE
Bump notifications-utils to 82.1.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -7,6 +7,6 @@ whitenoise==6.2.0  #manages static assets
 
 notifications-python-client==8.0.1
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@80.0.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@82.1.0
 govuk-frontend-jinja==3.1.0
 sentry_sdk[flask]>=1.0.0,<2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -76,7 +76,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==8.0.1
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@80.0.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@82.1.0
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils


### PR DESCRIPTION
[Trello](https://trello.com/c/JKMlpumI/835-include-payload-size-of-post-request-on-logs)

Bump notifications-utils to 82.1.0

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
