### PR TITLE
Add missing notify-environment. Used for logging

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -11,6 +11,10 @@ class Config:
     # Logging
     DEBUG = False
 
+    # The config option NOTIFY_ENVIRONMENT is purely used for logging.
+    # It should not be used for any logical conditionals in the code.
+    NOTIFY_ENVIRONMENT = os.environ["NOTIFY_ENVIRONMENT"]
+
     NOTIFY_REQUEST_LOG_LEVEL = os.getenv("NOTIFY_REQUEST_LOG_LEVEL", "INFO")
 
     DOCUMENT_DOWNLOAD_API_HOST_NAME = os.environ.get("DOCUMENT_DOWNLOAD_API_HOST_NAME")


### PR DESCRIPTION
What
----

Add missing notify-environment. Used for logging

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
