### PR TITLE
Add a note about how to bump utils version

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -7,6 +7,8 @@ whitenoise==6.2.0  #manages static assets
 
 notifications-python-client==8.0.1
 
+# Run `make bump-utils` to update to the latest version
 notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@82.1.1
+
 govuk-frontend-jinja==3.1.0
 sentry_sdk[flask]>=1.0.0,<2.0.0


### PR DESCRIPTION
You wouldn’t know about this without looking in the `Makefile`, and it’s easier to use the command than do it manually.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
