### PR TITLE
Add help text to all pages for consistency

### DIFF
--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -173,7 +173,10 @@ def confirm_email_address(service_id, document_id):
         render_template(
             "views/confirm_email_address.html",
             form=form,
+            service_name=service_name,
             service_id=service_id,
+            service_contact_info=service_contact_info,
+            contact_info_type=contact_info_type,
             document_id=document_id,
             key=key,
         ),

--- a/app/templates/views/confirm_email_address.html
+++ b/app/templates/views/confirm_email_address.html
@@ -27,6 +27,17 @@
           "type": "submit"
         }) }}
       </form>
+
+      <p class="govuk-body">
+        If you have any questions,
+        {% if contact_info_type == "link" %}
+          <a href="{{ service_contact_info }}" class="govuk-link" rel="noreferrer"> contact {{ service_name }}</a>.
+        {% elif contact_info_type == "email" %}
+          email <a href="mailto:{{ service_contact_info }}" class="govuk-link">{{ service_contact_info }}</a>.
+        {% else %}
+          call {{ service_contact_info }}.
+        {% endif %}
+      </p>
     </div>
   </div>
 {% endblock %}

--- a/app/templates/views/index.html
+++ b/app/templates/views/index.html
@@ -15,7 +15,7 @@
     }) }}
   </p>
   <p class="govuk-body">
-    If you’re not sure why you’ve been sent a file, or you have any questions,
+    If you have any questions,
     {% if contact_info_type == "link" %}
       <a href="{{ service_contact_info }}" class="govuk-link" rel="noreferrer"> contact {{ service_name }}</a>.
     {% elif contact_info_type == "email" %}

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -258,7 +258,7 @@ def test_landing_page_creates_link_to_confirm_email_address(
     )
 
 
-def test_confirm_email_address_page_show_email_address_form(
+def test_confirm_email_address_page_shows_email_address_form_and_contact_details(
     service_id,
     document_id,
     key,
@@ -284,6 +284,10 @@ def test_confirm_email_address_page_show_email_address_form(
     assert normalize_spaces(page.h1.text) == "Confirm your email address"
     assert page.select_one("form")
     assert not page.select(".govuk-error-summary")
+
+    contact_link = page.select("main a")[0]
+    assert contact_link.text.strip() == "contact Sample Service"
+    assert contact_link["href"] == "https://sample-service.gov.uk"
 
 
 def test_confirm_email_address_page_redirects_to_download_page_if_confirmation_not_required(


### PR DESCRIPTION
Following a prototyping session with @karlchillmaid and @RyanCee12 we decided to just copy the help text from the last page without any additional formatting (like inset text), so as to introduce as little visual noise as possible.

These changes are to help the app comply with the [consistent help success criterion (3.2.6) from WCAG 2.2](https://www.w3.org/WAI/WCAG22/Understanding/consistent-help) which asks us to put help in the same place across multiple pages of a process.

## Landing page

### Before

<img width="987" alt="image" src="https://github.com/user-attachments/assets/f5116929-4c47-43b3-a168-bfa8c9cedf1a">

### After

<img width="985" alt="image" src="https://github.com/user-attachments/assets/ed2f52e4-37e2-4bb4-9abc-97a60c292163">

### Before

<img width="992" alt="image" src="https://github.com/user-attachments/assets/956bfb84-2334-4b4b-ac85-e8d2a59de294">

### After

<img width="988" alt="image" src="https://github.com/user-attachments/assets/82fb5516-389c-4fe1-954b-c50594def2c2">

### Before

<img width="990" alt="image" src="https://github.com/user-attachments/assets/11bac492-939a-48b3-83f9-089cc08efd97">

### After


---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
