### PR TITLE
Version control requirements_for_test_common.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,6 @@ wheels/
 MANIFEST
 pyproject.toml
 .pre-commit-config.yaml
-requirements_for_test_common.txt
 
 # PyCharm
 .idea

--- a/requirements_for_test_common.txt
+++ b/requirements_for_test_common.txt
@@ -1,0 +1,14 @@
+# This file is automatically copied from notifications-utils@82.1.1
+
+beautifulsoup4==4.11.1
+pytest==7.2.0
+pytest-env==0.8.1
+pytest-mock==3.9.0
+pytest-xdist==3.0.2
+pytest-testmon==2.1.0
+pytest-watch==4.2.0
+requests-mock==1.10.0
+freezegun==1.2.2
+
+black==24.4.0  # Also update `.pre-commit-config.yaml` if this changes
+ruff==0.3.7  # Also update `.pre-commit-config.yaml` if this changes


### PR DESCRIPTION
We excluded this file from version control because it’s copied automatically from utils, so we only need to modify it and track changes there. In theory at least.

In practice Dependabot cannot:
- cope with having a requirements file which isn’t in the repo
- be configured to only look at certain requirements files

So I think the best thing to do is keep this file in version control. It already has an automatically generated comment to suggest it shouldn’t be edited manually.

Dependabot may try to raise PRs against it, but we can resolve these by updating the upstream version in utils. We can then roll out several version bumps in a single PR per app, rather than several.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
