### PR TITLE
Change port mapping to use the loopback address

### DIFF
--- a/scripts/run_locally_with_docker.sh
+++ b/scripts/run_locally_with_docker.sh
@@ -17,7 +17,7 @@ docker run -it --rm \
   -e DOCUMENT_DOWNLOAD_API_HOST_NAME_INTERNAL=$DOCUMENT_DOWNLOAD_API_HOST_NAME_INTERNAL \
   -e WERKZEUG_DEBUG_PIN=${WERKZEUG_DEBUG_PIN:-"off"} \
   -e PORT=${PORT} \
-  -p ${PORT}:${PORT} \
+  -p 127.0.0.1:${PORT}:${PORT} \
   -v $(pwd):/home/vcap/app \
   ${DOCKER_IMAGE_NAME} \
   ${@}


### PR DESCRIPTION
Docker defaults to using `0.0.0.0`, the default route listening on all network interfaces, as opposed to the loopback address (`127.0.0.1`). This has security implications and we have been asked to change it.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
