### PR TITLE
ServiceApiClient: refactor construction, use thread-local instances

### DIFF
--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -17,16 +17,15 @@ class OnwardsRequestNotificationsAPIClient(NotificationsAPIClient):
 
 
 class ServiceApiClient:
-    def __init__(self):
-        self.api_client = None
-
-    def init_app(self, application):
+    def __init__(self, app):
         self.api_client = OnwardsRequestNotificationsAPIClient(
-            base_url=application.config["API_HOST_NAME"],
-            api_key="a" * 75,
+            "x" * 100,
+            base_url=app.config["API_HOST_NAME"],
         )
-        self.api_client.service_id = application.config["ADMIN_CLIENT_USER_NAME"]
-        self.api_client.api_key = application.config["ADMIN_CLIENT_SECRET"]
+        # our credential lengths aren't what NotificationsAPIClient's __init__ will expect
+        # given it's designed for destructuring end-user api keys
+        self.api_client.service_id = app.config["ADMIN_CLIENT_USER_NAME"]
+        self.api_client.api_key = app.config["ADMIN_CLIENT_SECRET"]
 
     def get_service(self, service_id):
         """

--- a/requirements.in
+++ b/requirements.in
@@ -5,7 +5,7 @@ Flask-WTF==1.2.1
 
 whitenoise==6.2.0  #manages static assets
 
-notifications-python-client==8.0.1
+notifications-python-client==10.0.0
 
 # Run `make bump-utils` to update to the latest version
 notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@86.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -78,7 +78,7 @@ markupsafe==2.1.1
     #   wtforms
 mistune==0.8.4
     # via notifications-utils
-notifications-python-client==8.0.1
+notifications-python-client==10.0.0
     # via -r requirements.in
 notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@86.2.0
     # via -r requirements.in

--- a/tests/app/notify_client/test_service_api_client.py
+++ b/tests/app/notify_client/test_service_api_client.py
@@ -6,7 +6,7 @@ from app.notify_client.service_api_client import ServiceApiClient
 
 
 def test_client_gets_service(mocker):
-    client = ServiceApiClient()
+    client = ServiceApiClient(mocker.MagicMock())
     mock_api_client = mocker.patch.object(client, "api_client")
 
     client.get_service("foo")
@@ -14,8 +14,7 @@ def test_client_gets_service(mocker):
 
 
 def test_client_onward_headers(app_, rmock, service_id, sample_service):
-    client = ServiceApiClient()
-    client.init_app(app_)
+    client = ServiceApiClient(app_)
 
     rmock.get(
         "{}/service/{}".format(
@@ -41,8 +40,7 @@ def test_client_onward_headers(app_, rmock, service_id, sample_service):
 
 
 def test_client_no_onward_headers(app_, rmock, service_id, sample_service):
-    client = ServiceApiClient()
-    client.init_app(app_)
+    client = ServiceApiClient(app_)
 
     rmock.get(
         "{}/service/{}".format(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import pytest
 import requests_mock
 from flask import Flask, current_app
 
-from app import create_app
+from app import create_app, reset_memos
 
 
 @pytest.fixture
@@ -13,12 +13,14 @@ def app_(request):
     app = Flask("app")
     create_app(app)
 
+    reset_memos()
     ctx = app.app_context()
     ctx.push()
 
     yield app
 
     ctx.pop()
+    reset_memos()
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
Tangential to https://trello.com/c/ORGrd1jn/498-upgrade-docker-images-for-our-ecs-apps-to-debian-bookworm

This app uses eventlet, so `ServiceApiClient` use really needs to be made thread-safe because of its internal `requests.Session`.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
