### PR TITLE
application: use EventletTimeoutMiddleware if using eventlet

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,6 +8,7 @@ from notifications_utils import logging, request_helper
 from notifications_utils.asset_fingerprinter import asset_fingerprinter
 from notifications_utils.base64_uuid import base64_to_uuid, uuid_to_base64
 from notifications_utils.clients.statsd.statsd_client import StatsdClient
+from notifications_utils.eventlet import EventletTimeout
 from werkzeug.routing import BaseConverter, ValidationError
 
 from app.config import Config, configs
@@ -129,6 +130,11 @@ def register_errorhandlers(application):  # noqa (C901 too complex)
         application.logger.warning("CSRF error message: %s", reason)
 
         return _error_response(400, error_page_template=500)
+
+    @application.errorhandler(EventletTimeout)
+    def eventlet_timeout(error):
+        application.logger.exception(error)
+        return _error_response(504, error_page_template=500)
 
 
 def init_jinja(application):

--- a/application.py
+++ b/application.py
@@ -9,6 +9,8 @@ from whitenoise import WhiteNoise  # noqa
 
 from app import create_app  # noqa
 
+from notifications_utils.eventlet import EventletTimeoutMiddleware, using_eventlet  # noqa
+
 PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
 STATIC_ROOT = os.path.join(PROJECT_ROOT, "app", "static")
 STATIC_URL = "static/"
@@ -17,3 +19,6 @@ application = Flask("app")
 
 create_app(application)
 application.wsgi_app = WhiteNoise(application.wsgi_app, STATIC_ROOT, STATIC_URL)
+
+if using_eventlet:
+    application.wsgi_app = EventletTimeoutMiddleware(application.wsgi_app, timeout_seconds=30)


### PR DESCRIPTION
Also catch `EventletTimeout` exceptions, turning these into 504s, which are the closest thing to an application timeout standard codes seem to cover.

30s timeout as this is what we've decided to set our cloudfront/ALB timeouts to (we'll make this change shortly).

In `EventletTimeoutMiddleware`'s current implementation, the timeout gets cancelled as soon as the initial status response is returned, so streaming responses shouldn't be affected any more than normal responses

The wrapping differs from that in https://github.com/alphagov/notifications-api/pull/4209 and https://github.com/alphagov/notifications-admin/pull/5245 because I realize it's more correct to wrap `application.wsgi_app`. I'll switch the other applications to this approach when I loop back to them to set their timeouts to 30s.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
