### PR TITLE
notifications-utils: 86.2.0 -> 87.1.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -8,7 +8,7 @@ whitenoise==6.2.0  #manages static assets
 notifications-python-client==10.0.0
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@86.2.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@87.1.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains
 prometheus-client==0.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -80,7 +80,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==10.0.0
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@86.2.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@87.1.0
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils


### PR DESCRIPTION
Incorporating https://github.com/alphagov/notifications-utils/pull/1160

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
