### PR TITLE
Bump govuk-frontend to v5.7.1 and govuk-frontend-jinja to v3.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "govuk-frontend": "5.4.0"
+        "govuk-frontend": "5.7.1"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "21.0.1",
@@ -2586,9 +2586,9 @@
       "license": "MIT"
     },
     "node_modules/govuk-frontend": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.4.0.tgz",
-      "integrity": "sha512-F3YwQYrYQqIPfNxsoph6O78Ey1unCB6cy6omx8KeWY9G504lWZFBSIaiUCma1jNLw9bOUU7Ui+tXG09jjqy0Mw==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.7.1.tgz",
+      "integrity": "sha512-jF1cq5rn57kxZmJRprUZhTQ31zaBBK4b5AyeJaPX3Yhg22lk90Mx/dQLvOk/ycV3wM7e0y+s4IPvb2fFaPlCGg==",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -8959,9 +8959,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.4.0.tgz",
-      "integrity": "sha512-F3YwQYrYQqIPfNxsoph6O78Ey1unCB6cy6omx8KeWY9G504lWZFBSIaiUCma1jNLw9bOUU7Ui+tXG09jjqy0Mw=="
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.7.1.tgz",
+      "integrity": "sha512-jF1cq5rn57kxZmJRprUZhTQ31zaBBK4b5AyeJaPX3Yhg22lk90Mx/dQLvOk/ycV3wM7e0y+s4IPvb2fFaPlCGg=="
     },
     "graceful-fs": {
       "version": "4.2.8",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": "Government Digital Service",
   "license": "MIT",
   "dependencies": {
-    "govuk-frontend": "5.4.0"
+    "govuk-frontend": "5.7.1"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "21.0.1",

--- a/requirements.in
+++ b/requirements.in
@@ -14,5 +14,5 @@ notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@88
 prometheus-client==0.15.0
 git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72
 
-govuk-frontend-jinja==3.1.0
+govuk-frontend-jinja==3.4.0
 sentry_sdk[flask]>=1.0.0,<2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,7 +48,7 @@ gds-metrics @ git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6
     # via -r requirements.in
 govuk-bank-holidays==0.14
     # via notifications-utils
-govuk-frontend-jinja==3.1.0
+govuk-frontend-jinja==3.4.0
     # via -r requirements.in
 greenlet==3.0.3
     # via eventlet


### PR DESCRIPTION
Fixes: https://trello.com/c/zDuS5nzZ/1015-update-admin-and-document-download-apps-to-latest-design-system

Current latest, with new coat of arms

Top: before 
Bottom: after
<img width="183" alt="Screenshot 2024-11-01 at 07 52 56" src="https://github.com/user-attachments/assets/cf51ac47-4699-4705-8c62-4820bfba344c">


---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
