### PR TITLE
Allow PNG and JPEG file to be downloaded

### DIFF
--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -24,8 +24,10 @@ FILE_EXTENSION_TO_PRETTY_FILE_TYPE = {
     "docx": "Microsoft Word document",
     "odt": "text file",
     "pdf": "PDF",
+    "png": "PNG file",
     "rtf": "text file",
     "txt": "text file",
+    "jpeg": "JPEG file",
     "json": "JSON file",
     "xlsx": "Microsoft Excel spreadsheet",
 }

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -526,10 +526,17 @@ def test_download_document_creates_link_to_actual_doc_from_api(
 @pytest.mark.parametrize(
     "file_extension,expected_pretty_file_type",
     [
-        ("pdf", "PDF"),
-        ("txt", "text file"),
+        ("csv", "CSV file"),
+        ("doc", "Microsoft Word document"),
         ("docx", "Microsoft Word document"),
+        ("odt", "text file"),
+        ("pdf", "PDF"),
+        ("png", "PNG file"),
+        ("rtf", "text file"),
+        ("txt", "text file"),
+        ("jpeg", "JPEG file"),
         ("json", "JSON file"),
+        ("xlsx", "Microsoft Excel spreadsheet"),
     ],
 )
 def test_download_document_shows_pretty_file_type(


### PR DESCRIPTION
They can be now be uploaded in document-download-api, but when trying to download them in document-download-frontend was giving an key error (and `500` status) since their extensions didn't exist in `FILE_EXTENSION_TO_PRETTY_FILE_TYPE` dict.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
