### PR TITLE
Bump utils to 92.1.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@92.0.1
+# This file was automatically copied from notifications-utils@92.1.1
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@92.0.1
+# This file was automatically copied from notifications-utils@92.1.1
 
 [tool.black]
 line-length = 120

--- a/requirements.in
+++ b/requirements.in
@@ -8,7 +8,7 @@ whitenoise==6.2.0  #manages static assets
 notifications-python-client==10.0.0
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@92.0.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@92.1.1
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains
 prometheus-client==0.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,7 +57,7 @@ itsdangerous==2.2.0
     #   flask
     #   flask-wtf
     #   notifications-utils
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   flask
     #   govuk-frontend-jinja
@@ -76,7 +76,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==10.0.0
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@9d8b26f172643484612c4572c9ae72a41e262916
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@b9ef1b45b655324d6341995afffc3ebc25a3ed72
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -99,7 +99,7 @@ itsdangerous==2.2.0
     #   flask
     #   flask-wtf
     #   notifications-utils
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -r requirements.txt
     #   flask
@@ -124,7 +124,7 @@ mypy-extensions==1.0.0
     # via black
 notifications-python-client==10.0.0
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@9d8b26f172643484612c4572c9ae72a41e262916
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@b9ef1b45b655324d6341995afffc3ebc25a3ed72
     # via -r requirements.txt
 ordered-set==4.1.0
     # via

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@92.0.1
+# This file was automatically copied from notifications-utils@92.1.1
 
 beautifulsoup4==4.12.3
 pytest==8.3.4


### PR DESCRIPTION
 ## 92.1.1

* Bump minimum version of `jinja2` to 3.1.5

 ## 92.1.0

* RequestCache: add CacheResultWrapper to allow dynamic cache decisions

 ## 92.0.2

* Downgrade minimum version of `requests` to 2.32.3

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/92.0.1...92.1.1



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
