### PR TITLE
Add ITHC recommendation headers

### DIFF
--- a/app/templates/document_download_template.html
+++ b/app/templates/document_download_template.html
@@ -1,6 +1,8 @@
 {% extends "govuk_frontend_jinja/template.html" %}
 {% from "components/footer/macro.html" import govukFooterWithoutExternalLinks -%}
 
+{% set cspNonce = request.csp_nonce %}
+
 {% block headIcons %}
   <link rel="icon" sizes="48x48" href="{{ asset_url('images/favicon.ico') }}">
   <link rel="icon" sizes="any" href="{{ asset_url('images/favicon.svg') }}" type="image/svg+xml">
@@ -11,7 +13,7 @@
 
 {% block head %}
   <link rel="stylesheet" media="screen" href="{{ asset_url('stylesheets/main.css') }}" />
-  <style>
+  <style nonce="{{ cspNonce }}"> 
       .govuk-header__container { border-bottom-color: {{header_colour}} }
   </style>
   {% block meta %}

--- a/tests/app/test_headers.py
+++ b/tests/app/test_headers.py
@@ -1,0 +1,52 @@
+from flask import url_for
+
+
+def test_owasp_useful_headers_set(
+    service_id,
+    document_id,
+    key,
+    document_has_metadata_requires_confirmation,
+    client,
+    mocker,
+    sample_service,
+    fake_nonce,
+):
+    mocker.patch("secrets.token_urlsafe", return_value=fake_nonce)
+
+    mocker.patch("app.service_api_client.get_service", return_value={"data": sample_service})
+
+    response = client.get(
+        url_for(
+            "main.landing",
+            service_id=service_id,
+            document_id=document_id,
+            key=key,
+        )
+    )
+
+    assert response.headers["X-Robots-Tag"] == "noindex, nofollow"
+    assert response.headers["X-Frame-Options"] == "deny"
+    assert response.headers["X-Content-Type-Options"] == "nosniff"
+    assert response.headers["X-XSS-Protection"] == "1; mode=block"
+    assert response.headers["Content-Security-Policy"] == (
+        "default-src 'self';"
+        "script-src 'self' 'nonce-TESTs5Vr8v3jgRYLoQuVwA';"
+        "connect-src 'self';"
+        "object-src 'self';"
+        "font-src 'self' data:;"
+        "img-src 'self' data:;"
+        "style-src 'self' 'nonce-TESTs5Vr8v3jgRYLoQuVwA';"
+        "frame-ancestors 'self';"
+        "frame-src 'self';"
+    )
+
+    assert response.headers["Strict-Transport-Security"] == "max-age=31536000; preload"
+    assert response.headers["Referrer-Policy"] == "no-referrer"
+    assert response.headers["Cross-Origin-Embedder-Policy"] == "require-corp;"
+    assert response.headers["Cross-Origin-Opener-Policy"] == "same-origin;"
+    assert response.headers["Cross-Origin-Resource-Policy"] == "same-origin;"
+    assert (
+        response.headers["Permissions-Policy"]
+        == "geolocation=(), microphone=(), camera=(), autoplay=(), payment=(), sync-xhr=()"
+    )
+    assert response.headers["Server"] == "Cloudfront"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -93,3 +93,8 @@ def document_has_metadata_requires_confirmation(service_id, document_id, key, rm
         ),
         json=json_response,
     )
+
+
+@pytest.fixture(scope="function")
+def fake_nonce():
+    return "TESTs5Vr8v3jgRYLoQuVwA"


### PR DESCRIPTION
These are the security headers recommended for us for govuk alerts. Following last year’s ITHC we had a recommendation to add them in admin.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
