### PR TITLE
Update docker compose to use amd64 unit-tests-image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bookworm AS base
+FROM --platform=linux/amd64 python:3.11-slim-bookworm AS base
 
 ENV DEBIAN_FRONTEND=noninteractive \
     PYTHONUNBUFFERED=1 \


### PR DESCRIPTION
After recent change tp remove sh file, the new unit-tests-image does not work on mac because of the ghcr image only support amd64.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
