### PR TITLE
Format expiry date according to GOV.UK style

### DIFF
--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -227,8 +227,8 @@ def _format_file_expiry_date(available_until: str) -> str:
     # only show day of the week if file expiry date within a month from today
     if file_expiry_date - date.today() <= timedelta(days=30):
         return f"{day_of_week} {formatted_date}"
-    else:
-        return formatted_date
+
+    return formatted_date
 
 
 def _get_service_or_raise_error(service_id):

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -221,11 +221,14 @@ def download_document(service_id, document_id):
 def _format_file_expiry_date(available_until: str) -> str:
     file_expiry_date = parser.parse(available_until).date()
 
+    formatted_date = file_expiry_date.strftime("%d %B %Y")
+    day_of_week = file_expiry_date.strftime("%A")
+
     # only show day of the week if file expiry date within a month from today
     if file_expiry_date - date.today() <= timedelta(days=30):
-        return file_expiry_date.strftime("%A %d %B %Y")
+        return f"{day_of_week} {formatted_date}"
     else:
-        return file_expiry_date.strftime("%d %B %Y")
+        return formatted_date
 
 
 def _get_service_or_raise_error(service_id):

--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -221,7 +221,7 @@ def download_document(service_id, document_id):
 def _format_file_expiry_date(available_until: str) -> str:
     file_expiry_date = parser.parse(available_until).date()
 
-    formatted_date = file_expiry_date.strftime("%d %B %Y")
+    formatted_date = file_expiry_date.strftime("%d %B %Y").lstrip("0")
     day_of_week = file_expiry_date.strftime("%A")
 
     # only show day of the week if file expiry date within a month from today

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -576,7 +576,13 @@ def test_download_document_shows_contact_information(
 
 @freeze_time("2022-10-12 13:30")
 @pytest.mark.parametrize(
-    "days_till_expiry,expected_content", [(30, "Friday 11 November 2022"), (31, "12 November 2022")]
+    "days_till_expiry,expected_content",
+    [
+        (28, "Wednesday 9 November 2022"),
+        (30, "Friday 11 November 2022"),
+        (31, "12 November 2022"),
+        (50, "1 December 2022"),
+    ],
 )
 def test_download_document_shows_expiry_date(
     service_id, document_id, key, client, mocker, sample_service, days_till_expiry, expected_content


### PR DESCRIPTION
It should be 4 June 2017, not 04 June 2017.

https://www.gov.uk/guidance/style-guide/a-to-z#dates