### PR TITLE
Bump utils to 97.0.3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@95.1.1
+# This file was automatically copied from notifications-utils@97.0.3
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -1,6 +1,6 @@
 import os
 
-from notifications_utils.gunicorn_defaults import set_gunicorn_defaults
+from notifications_utils.gunicorn.defaults import set_gunicorn_defaults
 
 set_gunicorn_defaults(globals())
 

--- a/requirements.in
+++ b/requirements.in
@@ -8,7 +8,7 @@ whitenoise==6.2.0  #manages static assets
 notifications-python-client==10.0.0
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@95.1.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@97.0.3
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains
 prometheus-client==0.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,7 +57,7 @@ itsdangerous==2.2.0
     #   flask
     #   flask-wtf
     #   notifications-utils
-jinja2==3.1.5
+jinja2==3.1.6
     # via
     #   flask
     #   govuk-frontend-jinja
@@ -76,7 +76,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==10.0.0
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@361486ff4960b5d02c162118b1fd64b097f9cb96
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@3fb3caf0efc9ccbebfe79b3269f84bfd66fc90d5
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -96,7 +96,7 @@ itsdangerous==2.2.0
     #   flask
     #   flask-wtf
     #   notifications-utils
-jinja2==3.1.5
+jinja2==3.1.6
     # via
     #   -r requirements.txt
     #   flask
@@ -119,7 +119,7 @@ mistune==0.8.4
     #   notifications-utils
 notifications-python-client==10.0.0
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@361486ff4960b5d02c162118b1fd64b097f9cb96
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@3fb3caf0efc9ccbebfe79b3269f84bfd66fc90d5
     # via -r requirements.txt
 ordered-set==4.1.0
     # via

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@95.1.1
+# This file was automatically copied from notifications-utils@97.0.3
 
 beautifulsoup4==4.12.3
 pytest==8.3.4

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@95.1.1
+# This file was automatically copied from notifications-utils@97.0.3
 
 exclude = [
     "migrations/versions/",


### PR DESCRIPTION
 ## 97.0.3

* Bump minimum jinja2 version to 3.1.6 (closes #287)

 ## 97.0.2

* Fix external link redirect

 ## 97.0.1

* Fix QR code URL with '&' encoded as '&amp;'

 ## 97.0.0

* for bilingual letters preview, only show barcodes on the first page (patch).
* rename `include_notify_tag` argument to `includes_first_page` (major).

 ## 96.0.0

* BREAKING CHANGE: the `gunicorn_defaults` module has been moved to `gunicorn.defaults` to make space for gunicorn-related utils that don't have the restricted-import constraints of the gunicorn defaults. Imports of `notifications_utils.gunicorn_defaults` should be changed to `notifications_utils.gunicorn.defaults`.
* Added `ContextRecyclingEventletWorker` custom gunicorn worker class.

 ## 95.2.0

* Implement `InsensitiveSet.__contains__`

 ## 95.1.2

* Fix to the number of arguments the `on_retry` of the `NotifyTask` class takes.

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/95.1.1...97.0.3