### PR TITLE
Bump GOVUK Frontend to v5.9.0

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -5,6 +5,12 @@
 // set asset URL root to match that of application
 $govuk-assets-path: "/static/";
 
+// TODO: remove this when moving to a version of GOVUK Frontend above 6
+// The organisation colours will be set to the new ones by default from that version
+// See: https://github.com/alphagov/govuk-frontend/releases/tag/v5.9.0
+//      > Deprecated features > Migrate to the new organisation colour palette
+$govuk-new-organisation-colours: true;
+
 // Dependencies from GOV.UK Frontend
 // https://github.com/alphagov/govuk-frontend
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "govuk-frontend": "5.7.1"
+        "govuk-frontend": "5.9.0"
       },
       "devDependencies": {
         "@eslint/js": "9.15.0",
@@ -2422,9 +2422,9 @@
       "dev": true
     },
     "node_modules/govuk-frontend": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.7.1.tgz",
-      "integrity": "sha512-jF1cq5rn57kxZmJRprUZhTQ31zaBBK4b5AyeJaPX3Yhg22lk90Mx/dQLvOk/ycV3wM7e0y+s4IPvb2fFaPlCGg==",
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.9.0.tgz",
+      "integrity": "sha512-8NzmyoDtRFYyHs413DfNPR8Zo6qw6Q02Mruxml/Yfy+EueaOI/JZ4gVM8d0pqzJmTiMcJuHhvxqYEgBRmqeoyA==",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -6329,9 +6329,9 @@
       "dev": true
     },
     "govuk-frontend": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.7.1.tgz",
-      "integrity": "sha512-jF1cq5rn57kxZmJRprUZhTQ31zaBBK4b5AyeJaPX3Yhg22lk90Mx/dQLvOk/ycV3wM7e0y+s4IPvb2fFaPlCGg=="
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.9.0.tgz",
+      "integrity": "sha512-8NzmyoDtRFYyHs413DfNPR8Zo6qw6Q02Mruxml/Yfy+EueaOI/JZ4gVM8d0pqzJmTiMcJuHhvxqYEgBRmqeoyA=="
     },
     "graceful-fs": {
       "version": "4.2.8",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "Government Digital Service",
   "license": "MIT",
   "dependencies": {
-    "govuk-frontend": "5.7.1"
+    "govuk-frontend": "5.9.0"
   },
   "devDependencies": {
     "@eslint/js": "9.15.0",

--- a/requirements.in
+++ b/requirements.in
@@ -14,5 +14,5 @@ notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@97
 prometheus-client==0.15.0
 git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72
 
-govuk-frontend-jinja==3.4.0
+govuk-frontend-jinja==3.5.0
 sentry-sdk[flask]==1.45.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ gds-metrics @ git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6
     # via -r requirements.in
 govuk-bank-holidays==0.15
     # via notifications-utils
-govuk-frontend-jinja==3.4.0
+govuk-frontend-jinja==3.5.0
     # via -r requirements.in
 greenlet==3.0.3
     # via eventlet

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -74,7 +74,7 @@ govuk-bank-holidays==0.15
     # via
     #   -r requirements.txt
     #   notifications-utils
-govuk-frontend-jinja==3.4.0
+govuk-frontend-jinja==3.5.0
     # via -r requirements.txt
 greenlet==3.0.3
     # via


### PR DESCRIPTION
One of the tasks in https://trello.com/c/eztuoh8p/1223-bump-design-system-to-version-before-govuk-rebrand-on-all-websites.

Brings in the following:
- https://github.com/alphagov/govuk-frontend/releases/tag/v5.9.0
- https://github.com/alphagov/govuk-frontend/releases/tag/v5.8.0
- https://github.com/alphagov/govuk-frontend/releases/tag/v5.7.1

This app doesn't have any custom CSS, other than [configuring which bits of the GOVUK Frontend Sass it uses](https://github.com/alphagov/document-download-frontend/blob/main/app/assets/stylesheets/main.scss) so doesn't actually use the departmental colours. We set the `$govuk-new-organisation-colours` flag here just to silence the deprecation warnings you see when compiling your Sass.