### PR TITLE
Refactor error handling

### DIFF
--- a/app/main/views/index.py
+++ b/app/main/views/index.py
@@ -7,7 +7,7 @@ from flask import abort, current_app, redirect, render_template, request, url_fo
 from flask.ctx import has_request_context
 from markupsafe import Markup
 from notifications_python_client.errors import HTTPError
-from werkzeug.exceptions import TooManyRequests
+from werkzeug.exceptions import Gone, TooManyRequests
 
 from app import service_api_client
 from app.forms import EmailAddressForm
@@ -70,17 +70,20 @@ def landing(service_id, document_id):
 
     service = _get_service_or_raise_error(service_id)
 
+    service_name = service["data"]["name"]
     service_contact_info = service["data"]["contact_link"]
     contact_info_type = assess_contact_type(service_contact_info)
-    metadata = _get_document_metadata(service_id, document_id, key)
 
-    if not metadata or document_has_expired(metadata["available_until"]):
+    try:
+        metadata = _get_document_metadata(service_id, document_id, key)
+    except Gone:
+        # pretty-up this particular error with more context
         return render_template(
             "views/file_unavailable.html",
-            service_name=service["data"]["name"],
+            service_name=service_name,
             service_contact_info=service_contact_info,
             contact_info_type=contact_info_type,
-        )
+        ), 410
 
     if "confirm_email" not in metadata:
         current_app.logger.info(
@@ -97,7 +100,7 @@ def landing(service_id, document_id):
     return render_template(
         "views/index.html",
         service_id=service_id,
-        service_name=service["data"]["name"],
+        service_name=service_name,
         service_contact_info=service_contact_info,
         contact_info_type=contact_info_type,
         document_id=document_id,
@@ -114,18 +117,20 @@ def confirm_email_address(service_id, document_id):
 
     service = _get_service_or_raise_error(service_id)
 
-    metadata = _get_document_metadata(service_id, document_id, key)
-    service_contact_info = service["data"]["contact_link"]
     service_name = service["data"]["name"]
+    service_contact_info = service["data"]["contact_link"]
     contact_info_type = assess_contact_type(service_contact_info)
 
-    if not metadata or document_has_expired(metadata["available_until"]):
+    try:
+        metadata = _get_document_metadata(service_id, document_id, key)
+    except Gone:
+        # pretty-up this particular error with more context
         return render_template(
             "views/file_unavailable.html",
             service_name=service_name,
             service_contact_info=service_contact_info,
             contact_info_type=contact_info_type,
-        )
+        ), 410
 
     if metadata["confirm_email"] is False:
         return redirect(url_for(".download_document", service_id=service_id, document_id=document_id, key=key))
@@ -194,27 +199,30 @@ def download_document(service_id, document_id):
 
     service = _get_service_or_raise_error(service_id)
 
-    metadata = _get_document_metadata(service_id, document_id, key)
+    service_name = service["data"]["name"]
     service_contact_info = service["data"]["contact_link"]
     contact_info_type = assess_contact_type(service_contact_info)
 
-    if not metadata or document_has_expired(metadata["available_until"]):
+    try:
+        metadata = _get_document_metadata(service_id, document_id, key)
+    except Gone:
+        # pretty-up this particular error with more context
         return render_template(
             "views/file_unavailable.html",
-            service_name=service["data"]["name"],
+            service_name=service_name,
             service_contact_info=service_contact_info,
             contact_info_type=contact_info_type,
-        )
+        ), 410
 
     return render_template(
         "views/download.html",
         download_link=metadata["direct_file_url"],
         file_size=bytes_to_pretty_file_size(metadata["size_in_bytes"]),
         file_type=FILE_EXTENSION_TO_PRETTY_FILE_TYPE[metadata["file_extension"]],
-        service_name=service["data"]["name"],
+        service_name=service_name,
         service_contact_info=service_contact_info,
         contact_info_type=contact_info_type,
-        file_expiry_date=_format_file_expiry_date(metadata["available_until"]),
+        file_expiry_date=_format_file_expiry_date(metadata["available_until"]) if metadata["available_until"] else None,
     )
 
 
@@ -248,18 +256,29 @@ def _get_document_metadata(service_id, document_id, key):
 
     response = requests.get(check_file_url, headers=headers)
 
-    if response.status_code == 400:
-        error_msg = response.json().get("error", "")
-        # If the decryption key is missing or can't be decoded using `urlsafe_b64decode`,
-        # the error message will contain 'decryption key'.
-        # If the decryption key is wrong, the error message is 'Forbidden'
-        if "decryption key" in error_msg or "Forbidden" in error_msg:
+    match response.status_code:
+        case 400:
+            # old-style document-download-api response handling
+            error_msg = response.json().get("error", "")
+            # If the decryption key is missing or can't be decoded using `urlsafe_b64decode`,
+            # the error message will contain 'decryption key'.
+            # If the decryption key is wrong, the error message is 'Forbidden'
+            if "decryption key" in error_msg or "Forbidden" in error_msg:
+                abort(404)
+        case 404 | 403:
             abort(404)
+        case 410:
+            abort(410)
 
     # Let the `500` error handler handle unexpected errors from doc-download-api
     response.raise_for_status()
 
-    return response.json().get("document")
+    metadata = response.json().get("document")
+    # old-style document-download-api response handling with leniency for missing available_until
+    if metadata is None or (metadata["available_until"] and document_has_expired(metadata["available_until"])):
+        abort(410)
+
+    return metadata
 
 
 def _authenticate_access_to_document(service_id, document_id, key, email_address) -> dict | None:

--- a/app/templates/views/download.html
+++ b/app/templates/views/download.html
@@ -14,7 +14,11 @@
   </p>
 
   <p class="govuk-body">
-    This file is available until {{file_expiry_date}}.
+  {% if file_expiry_date %}
+    This file is available until {{ file_expiry_date }}.
+  {% else %}
+    File expiry information is temporarily unavailable.
+  {% endif %}
   </p>
 
   <p class="govuk-body">

--- a/app/templates/views/file_unavailable.html
+++ b/app/templates/views/file_unavailable.html
@@ -1,13 +1,29 @@
 {% extends "document_download_template.html" %}
 
 {% block per_page_title %}
-  No longer available
+  {% if status_code == 410 %}
+    No longer available
+  {% elif status_code == 404 %}
+    Page not found
+  {% endif %}
 {% endblock %}
 
 {% block main_content %}
+  {% if status_code == 410 %}
   <p class="govuk-body">
     The file {{ service_name }} sent you has expired or been deleted.
   </p>
+  {% elif status_code == 404 %}
+  <p class="govuk-body">
+    If you selected a link in an email, the file may have expired or been deleted.
+  </p>
+  <p class="govuk-body">
+    If you typed the web address, check it is correct.
+  </p>
+  <p class="govuk-body">
+    If you pasted the web address, check you copied the entire address.
+  </p>
+  {% endif %}
 
   <p class="govuk-body">
     If you have any questions,

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -105,9 +105,23 @@ def test_notifications_api_error(view, method, service_id, document_id, client, 
         ("main.confirm_email_address", "post"),
     ],
 )
-def test_when_document_is_unavailable(view, method, service_id, document_id, key, client, mocker, sample_service):
+def test_when_document_is_unavailable(
+    view, method, service_id, document_id, key, client, sample_service, rmock, mocker
+):
+    mocker.patch(
+        "notifications_utils.request_helper.NotifyRequest.get_onwards_request_headers",
+        return_value={"some-onwards": "request-header"},
+    )
     mocker.patch("app.service_api_client.get_service", return_value={"data": sample_service})
-    mocker.patch("app.main.views.index._get_document_metadata", return_value=None)
+
+    rmock.get(
+        "{}/services/{}/documents/{}/check?key={}".format(
+            current_app.config["DOCUMENT_DOWNLOAD_API_HOST_NAME_INTERNAL"], service_id, document_id, key
+        ),
+        status_code=404,
+        json={"Error": "Nope"},
+    )
+
     response = client.open(
         url_for(
             view,
@@ -118,39 +132,202 @@ def test_when_document_is_unavailable(view, method, service_id, document_id, key
         method=method,
     )
 
-    assert response.status_code == 200
+    assert response.status_code == 404
+    page = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
+    assert normalize_spaces(page.h1.text) == "Page not found"
+
+    assert len(rmock.request_history) == 1
+    assert rmock.request_history[0].method == "GET"
+    assert rmock.request_history[0].url == "{}/services/{}/documents/{}/check?key={}".format(
+        current_app.config["DOCUMENT_DOWNLOAD_API_HOST_NAME_INTERNAL"],
+        service_id,
+        document_id,
+        key,
+    )
+    assert rmock.request_history[0].headers == AnySupersetOf({"some-onwards": "request-header"})
+
+
+@pytest.mark.parametrize(
+    "view, method",
+    [
+        ("main.landing", "get"),
+        ("main.download_document", "get"),
+        ("main.confirm_email_address", "get"),
+        ("main.confirm_email_address", "post"),
+    ],
+)
+def test_when_document_is_unavailable_old_api(
+    view, method, service_id, document_id, key, client, sample_service, rmock, mocker
+):
+    mocker.patch(
+        "notifications_utils.request_helper.NotifyRequest.get_onwards_request_headers",
+        return_value={"some-onwards": "request-header"},
+    )
+    mocker.patch("app.service_api_client.get_service", return_value={"data": sample_service})
+
+    rmock.get(
+        "{}/services/{}/documents/{}/check?key={}".format(
+            current_app.config["DOCUMENT_DOWNLOAD_API_HOST_NAME_INTERNAL"], service_id, document_id, key
+        ),
+        status_code=200,
+        json={"document": None},
+    )
+
+    response = client.open(
+        url_for(
+            view,
+            service_id=service_id,
+            document_id=document_id,
+            key=key,
+        ),
+        method=method,
+    )
+
+    # old-style api can't differentiate between missing and gone - all treated as gone
+    assert response.status_code == 410
     page = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
     assert normalize_spaces(page.h1.text) == "No longer available"
 
     contact_link = page.select("main a")[0]
     assert normalize_spaces(contact_link.text) == "contact Sample Service"
     assert contact_link["href"] == "https://sample-service.gov.uk"
+
+    assert len(rmock.request_history) == 1
+    assert rmock.request_history[0].method == "GET"
+    assert rmock.request_history[0].url == "{}/services/{}/documents/{}/check?key={}".format(
+        current_app.config["DOCUMENT_DOWNLOAD_API_HOST_NAME_INTERNAL"],
+        service_id,
+        document_id,
+        key,
+    )
+    assert rmock.request_history[0].headers == AnySupersetOf({"some-onwards": "request-header"})
 
 
 @pytest.mark.parametrize("view", ("main.landing", "main.confirm_email_address", "main.download_document"))
 def test_download_document_returns_file_unavailable_if_file_past_expiry_date(
-    service_id, document_id, key, client, mocker, sample_service, view
+    service_id, document_id, key, client, sample_service, view, rmock, mocker
 ):
+    mocker.patch(
+        "notifications_utils.request_helper.NotifyRequest.get_onwards_request_headers",
+        return_value={"some-onwards": "request-header"},
+    )
     mocker.patch("app.service_api_client.get_service", return_value={"data": sample_service})
 
-    mocked_metadata = {
-        "direct_file_url": "url",
-        "confirm_email": False,
-        "size_in_bytes": 712099,
-        "file_extension": "pdf",
-        "available_until": str(date.today() - timedelta(days=1)),
-    }
-    mocker.patch("app.main.views.index._get_document_metadata", return_value=mocked_metadata)
+    rmock.get(
+        "{}/services/{}/documents/{}/check?key={}".format(
+            current_app.config["DOCUMENT_DOWNLOAD_API_HOST_NAME_INTERNAL"], service_id, document_id, key
+        ),
+        status_code=410,
+        json={"Error": "Gone"},
+    )
 
     response = client.get(url_for(view, service_id=service_id, document_id=document_id, key=key))
 
-    assert response.status_code == 200
+    assert response.status_code == 410
     page = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
     assert normalize_spaces(page.h1.text) == "No longer available"
 
     contact_link = page.select("main a")[0]
     assert normalize_spaces(contact_link.text) == "contact Sample Service"
     assert contact_link["href"] == "https://sample-service.gov.uk"
+
+    assert len(rmock.request_history) == 1
+    assert rmock.request_history[0].method == "GET"
+    assert rmock.request_history[0].url == "{}/services/{}/documents/{}/check?key={}".format(
+        current_app.config["DOCUMENT_DOWNLOAD_API_HOST_NAME_INTERNAL"],
+        service_id,
+        document_id,
+        key,
+    )
+    assert rmock.request_history[0].headers == AnySupersetOf({"some-onwards": "request-header"})
+
+
+@pytest.mark.parametrize("view", ("main.landing", "main.confirm_email_address", "main.download_document"))
+def test_download_document_returns_file_unavailable_if_file_past_expiry_date_old_api(
+    service_id, document_id, key, client, sample_service, view, rmock, mocker
+):
+    mocker.patch(
+        "notifications_utils.request_helper.NotifyRequest.get_onwards_request_headers",
+        return_value={"some-onwards": "request-header"},
+    )
+    mocker.patch("app.service_api_client.get_service", return_value={"data": sample_service})
+
+    rmock.get(
+        "{}/services/{}/documents/{}/check?key={}".format(
+            current_app.config["DOCUMENT_DOWNLOAD_API_HOST_NAME_INTERNAL"], service_id, document_id, key
+        ),
+        status_code=200,
+        json={
+            "document": {
+                "direct_file_url": "url",
+                "confirm_email": False,
+                "size_in_bytes": 712099,
+                "file_extension": "pdf",
+                "available_until": str(date.today() - timedelta(days=1)),
+            }
+        },
+    )
+
+    response = client.get(url_for(view, service_id=service_id, document_id=document_id, key=key))
+
+    assert response.status_code == 410
+    page = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
+    assert normalize_spaces(page.h1.text) == "No longer available"
+
+    contact_link = page.select("main a")[0]
+    assert normalize_spaces(contact_link.text) == "contact Sample Service"
+    assert contact_link["href"] == "https://sample-service.gov.uk"
+
+    assert len(rmock.request_history) == 1
+    assert rmock.request_history[0].method == "GET"
+    assert rmock.request_history[0].url == "{}/services/{}/documents/{}/check?key={}".format(
+        current_app.config["DOCUMENT_DOWNLOAD_API_HOST_NAME_INTERNAL"],
+        service_id,
+        document_id,
+        key,
+    )
+    assert rmock.request_history[0].headers == AnySupersetOf({"some-onwards": "request-header"})
+
+
+@pytest.mark.parametrize("view", ("main.landing", "main.confirm_email_address", "main.download_document"))
+def test_download_document_succeeds_if_missing_available_until(
+    service_id, document_id, key, client, sample_service, view, rmock, mocker
+):
+    mocker.patch(
+        "notifications_utils.request_helper.NotifyRequest.get_onwards_request_headers",
+        return_value={"some-onwards": "request-header"},
+    )
+    mocker.patch("app.service_api_client.get_service", return_value={"data": sample_service})
+
+    rmock.get(
+        "{}/services/{}/documents/{}/check?key={}".format(
+            current_app.config["DOCUMENT_DOWNLOAD_API_HOST_NAME_INTERNAL"], service_id, document_id, key
+        ),
+        status_code=200,
+        json={
+            "document": {
+                "direct_file_url": "url",
+                "confirm_email": False,
+                "size_in_bytes": 712099,
+                "file_extension": "pdf",
+                "available_until": None,
+            }
+        },
+    )
+
+    response = client.get(url_for(view, service_id=service_id, document_id=document_id, key=key))
+
+    assert response.status_code < 400
+
+    assert len(rmock.request_history) == 1
+    assert rmock.request_history[0].method == "GET"
+    assert rmock.request_history[0].url == "{}/services/{}/documents/{}/check?key={}".format(
+        current_app.config["DOCUMENT_DOWNLOAD_API_HOST_NAME_INTERNAL"],
+        service_id,
+        document_id,
+        key,
+    )
+    assert rmock.request_history[0].headers == AnySupersetOf({"some-onwards": "request-header"})
 
 
 @pytest.mark.parametrize(
@@ -170,9 +347,18 @@ def test_download_document_returns_file_unavailable_if_file_past_expiry_date(
         {"error": "Forbidden"},
     ],
 )
+@pytest.mark.parametrize(
+    "api_status_code",
+    [
+        400,
+        404,
+        403,
+    ],
+)
 def test_404_hides_incorrect_credentials(
     view,
     method,
+    api_status_code,
     client,
     service_id,
     document_id,
@@ -192,7 +378,7 @@ def test_404_hides_incorrect_credentials(
         "{}/services/{}/documents/{}/check?key={}".format(
             current_app.config["DOCUMENT_DOWNLOAD_API_HOST_NAME_INTERNAL"], service_id, document_id, key
         ),
-        status_code=400,
+        status_code=api_status_code,
         json=json_response,
     )
     response = client.open(
@@ -557,6 +743,24 @@ def test_download_document_shows_pretty_file_type(
     assert response.status_code == 200
     page = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
     assert page.select("main a")[0].text == f"Download this {expected_pretty_file_type} (0.7MB) to your device"
+
+
+def test_download_document_handles_missing_expiry(service_id, document_id, key, client, mocker, sample_service):
+    mocker.patch("app.service_api_client.get_service", return_value={"data": sample_service})
+    mocked_metadata = {
+        "direct_file_url": "url",
+        "confirm_email": False,
+        "size_in_bytes": 712099,
+        "file_extension": "csv",
+        "available_until": None,
+    }
+    mocker.patch("app.main.views.index._get_document_metadata", return_value=mocked_metadata)
+
+    response = client.get(url_for("main.download_document", service_id=service_id, document_id=document_id, key=key))
+
+    assert response.status_code == 200
+    page = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
+    assert any(("File expiry information is temporarily unavailable" in elem.text) for elem in page.select("main p"))
 
 
 def test_download_document_shows_contact_information(

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -135,6 +135,8 @@ def test_when_document_is_unavailable(
     assert response.status_code == 404
     page = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
     assert normalize_spaces(page.h1.text) == "Page not found"
+    # ensure this is our contextualized 404 page
+    assert any((sample_service["name"] in elem.text) for elem in page.select("main p"))
 
     assert len(rmock.request_history) == 1
     assert rmock.request_history[0].method == "GET"
@@ -386,6 +388,10 @@ def test_404_hides_incorrect_credentials(
         method=method,
     )
     assert response.status_code == 404
+    page = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
+    assert normalize_spaces(page.h1.text) == "Page not found"
+    # ensure this is our contextualized 404 page
+    assert any((sample_service["name"] in elem.text) for elem in page.select("main p"))
 
     assert len(rmock.request_history) == 1
     assert rmock.request_history[0].method == "GET"


### PR DESCRIPTION
https://trello.com/c/EmuRWKZy/1037-experiment-with-removing-mrap-from-document-downloads-bucket

This introduces changes that appropriately handle non-400 error responses from the document-download-api while continuing to handle "old style" 400-status-code responses where the semantic meaning of the error needs to be sniffed out of the body. This should allow smooth rollout of the document-download-api change.

Once that has happened we can remove the old-style error handling and also expiration enforcement as that will have been moved into document-download-api.

This change also returns appropriate status codes to the user's browser for missing or inaccessible documents, adapting the existing `file_unavailable.html` template into a multi-purpose error page that allows us to supply more context to the end-user (service name and contact details) in the special case where we know the service id is valid and the other expected url components are present and well-formed. In such a case we don't *necessarily* know whether a link has been mis-pasted or the document has expired as we may not have empty delete markers immediately following migration.