### PR TITLE
Bump utils to 99.5.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@97.0.3
+# This file was automatically copied from notifications-utils@99.5.1
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -9,7 +9,7 @@ repos:
   - id: check-yaml
   - id: debug-statements
 - repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: 'v0.9.2'
+  rev: 'v0.11.4'
   hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]

--- a/requirements.in
+++ b/requirements.in
@@ -8,7 +8,7 @@ whitenoise==6.2.0  #manages static assets
 notifications-python-client==10.0.0
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@97.0.3
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@99.5.1
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains
 prometheus-client==0.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ docopt==0.6.2
     # via notifications-python-client
 eventlet==0.39.1
     # via gunicorn
-flask==3.1.0
+flask==3.1.1
     # via
     #   flask-redis
     #   flask-wtf
@@ -68,6 +68,7 @@ jmespath==0.10.0
     #   botocore
 markupsafe==2.1.1
     # via
+    #   flask
     #   jinja2
     #   sentry-sdk
     #   werkzeug
@@ -76,7 +77,7 @@ mistune==0.8.4
     # via notifications-utils
 notifications-python-client==10.0.0
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@3fb3caf0efc9ccbebfe79b3269f84bfd66fc90d5
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@d669a9544cc87372a10af8786d3bb172593261fa
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils
@@ -94,7 +95,7 @@ pypdf==3.17.0
     # via notifications-utils
 python-dateutil==2.8.2
     # via botocore
-python-json-logger==2.0.7
+python-json-logger==3.3.0
     # via notifications-utils
 pytz==2024.2
     # via notifications-utils

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -53,7 +53,7 @@ eventlet==0.39.1
     #   gunicorn
 execnet==2.1.1
     # via pytest-xdist
-flask==3.1.0
+flask==3.1.1
     # via
     #   -r requirements.txt
     #   flask-redis
@@ -110,6 +110,7 @@ jmespath==0.10.0
 markupsafe==2.1.1
     # via
     #   -r requirements.txt
+    #   flask
     #   jinja2
     #   werkzeug
     #   wtforms
@@ -119,7 +120,7 @@ mistune==0.8.4
     #   notifications-utils
 notifications-python-client==10.0.0
     # via -r requirements.txt
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@3fb3caf0efc9ccbebfe79b3269f84bfd66fc90d5
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@d669a9544cc87372a10af8786d3bb172593261fa
     # via -r requirements.txt
 ordered-set==4.1.0
     # via
@@ -168,7 +169,7 @@ python-dateutil==2.8.2
     #   -r requirements.txt
     #   botocore
     #   freezegun
-python-json-logger==2.0.7
+python-json-logger==3.3.0
     # via
     #   -r requirements.txt
     #   notifications-utils
@@ -193,7 +194,7 @@ requests==2.32.3
     #   requests-mock
 requests-mock==1.12.1
     # via -r requirements_for_test_common.in
-ruff==0.9.2
+ruff==0.11.4
     # via -r requirements_for_test_common.in
 s3transfer==0.10.1
     # via

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@97.0.3
+# This file was automatically copied from notifications-utils@99.5.1
 
 beautifulsoup4==4.12.3
 pytest==8.3.4
@@ -9,4 +9,4 @@ pytest-testmon==2.1.1
 requests-mock==1.12.1
 freezegun==1.5.1
 
-ruff==0.9.2  # Also update `.pre-commit-config.yaml` if this changes
+ruff==0.11.4  # Also update `.pre-commit-config.yaml` if this changes

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,10 +1,8 @@
-# This file was automatically copied from notifications-utils@97.0.3
+# This file was automatically copied from notifications-utils@99.5.1
 
-exclude = [
+extend-exclude = [
     "migrations/versions/",
-    "venv*",
     "__pycache__",
-    "node_modules",
     "cache",
     "migrations",
     "build",


### PR DESCRIPTION
 ## 99.5.1

* Bump minimum Flask version to 3.1.1

 ## 99.5.0

* Update economy letter transit date to 5 days

 ## 99.4.1

* Fix celery beat logging so that it will log in json

 ## 99.4.0

* Add celery logging configuration for json logging

 ## 99.3.4

* `celery.NotifyTask`: don't emit early log if called synchronously

 ## 99.3.3

* Fix bug with non-SMS templates considering international SMS limits

 ## 99.3.2

* Stops counting Crown Dependency phone numbers in CSV file as international

 ## 99.3.1

* Bump `python-json-logger` to version 3

 ## 99.3.0

* Adds `RecipientCSV.international_sms_count`
* Adds `RecipientCSV.more_international_sms_than_can_send` (initialise per `RecipientCSV(remaining_international_sms_messages=123)` to enable this check)

 ## 99.2.0

* Add s3 multipart upload lifecycle (create, upload, complete, abort)

 ## 99.1.2

* Normalise unusual dashes and spacing characters in phone numbers

 ## 99.1.1

* Bump ruff to latest version

 ## 99.1.0

* Adds support for economy mail in get_min_and_max_days_in_transit, with delivery estimated between 2 and 6 days

 ## 99.0.0

* NOTABLE CHANGE: Celery tasks emit an "early" log message when starting, with a customisable log level to allow this to be disabled for high-volume tasks. When upgrading past this version you may want to pass the extra argument `early_log_level=logging.DEBUG` to the task decorator of your most heavily-called tasks to reduce the effect on log volume
* Annotates automatic celery task log messages with `celery_task_id`

 ## 98.0.1

* Moves from `setup.py` to `pyproject.toml` for package configuation
* Changes ruff config from `exclude` to `extend-exclude`

 ## 98.0.0

* Update rate multipliers for international SMS to have values for 1 April 2025 onwards. When used in notifications-api and notifications-admin this change will affect the billing of text messages the pricing shown.

 ## 97.0.5

* Fix mailto: URLs in Markdown links

 ## 97.0.4

* Fix inset text block styling

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/97.0.3...99.5.1