### PR TITLE
Bump greenlet to the latest version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ govuk-bank-holidays==0.15
     # via notifications-utils
 govuk-frontend-jinja==3.6.0
     # via -r requirements.in
-greenlet==3.0.3
+greenlet==3.2.2
     # via eventlet
 gunicorn==23.0.0
     # via notifications-utils

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -76,7 +76,7 @@ govuk-bank-holidays==0.15
     #   notifications-utils
 govuk-frontend-jinja==3.6.0
     # via -r requirements.txt
-greenlet==3.0.3
+greenlet==3.2.2
     # via
     #   -r requirements.txt
     #   eventlet


### PR DESCRIPTION
The version we are using does not install on newer versions of Python because of the way it is packaged