### PR TITLE
Bump govuk-frontend to v5.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "govuk-frontend": "5.10.2"
+        "govuk-frontend": "5.11.0"
       },
       "devDependencies": {
         "@eslint/js": "9.22.0",
@@ -2466,9 +2466,9 @@
       "dev": true
     },
     "node_modules/govuk-frontend": {
-      "version": "5.10.2",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.10.2.tgz",
-      "integrity": "sha512-eVYB2rfUCihehZFHQyylt12/OuXq2JLs+70igcrB1FmbepcDqs1XwKiq96hsPbPF9Vn2f6QXO1OatyD3bq5c9Q==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.11.0.tgz",
+      "integrity": "sha512-RYZDEF1J6nVw5XauQGH+91qplExgHUXfXII7dtIme6I4u3eSvU59yZ0/EFKEwRgTslSqlhJODOnAi5rnQFU5Gw==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"
@@ -6459,9 +6459,9 @@
       "dev": true
     },
     "govuk-frontend": {
-      "version": "5.10.2",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.10.2.tgz",
-      "integrity": "sha512-eVYB2rfUCihehZFHQyylt12/OuXq2JLs+70igcrB1FmbepcDqs1XwKiq96hsPbPF9Vn2f6QXO1OatyD3bq5c9Q=="
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.11.0.tgz",
+      "integrity": "sha512-RYZDEF1J6nVw5XauQGH+91qplExgHUXfXII7dtIme6I4u3eSvU59yZ0/EFKEwRgTslSqlhJODOnAi5rnQFU5Gw=="
     },
     "graceful-fs": {
       "version": "4.2.8",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "Government Digital Service",
   "license": "MIT",
   "dependencies": {
-    "govuk-frontend": "5.10.2"
+    "govuk-frontend": "5.11.0"
   },
   "devDependencies": {
     "@eslint/js": "9.22.0",


### PR DESCRIPTION
Release notes: https://github.com/alphagov/govuk-frontend/releases/tag/v5.11.0

- rebrand svg icon fixes
- service navigation fixes