### PR TITLE
Dockerfile: use base image for frontend_build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /home/vcap/app
 
 ##### Frontend Build Image ###################################################
 FROM --platform=linux/amd64 node:22-slim AS node
-FROM --platform=linux/amd64 python:3.11-slim AS frontend_build
+FROM base AS frontend_build
 
 SHELL ["/bin/bash", "-c"]
 


### PR DESCRIPTION
Our images are currently failing to build because it seems the default `python` image (which we use as `frontend_build`) has been upgraded to debian trixie (the new release). Trixie has a different glibc, so binaries between the two distros are not interchangeable.

We already have a perfectly fine `python` image as `base`, so let's just reuse that for frontend building.