### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+    labels:
+      - dependencies
+      - python


### PR DESCRIPTION
Restricts dependabot to only raise pull requests for Python dependancies and only for security updates. The `open-pull-requests-limit: 0` only applies to version updates, not security updates:

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#open-pull-requests-limit

This copies what was done with https://github.com/alphagov/notifications-admin/pull/5603