### PR TITLE
Add min-release-age=7 config to npmrc and use it in CI as well

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 ignore-scripts=true
+min-release-age=7

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,7 +22,7 @@ SHELL ["/bin/bash", "-c"]
 
 WORKDIR /usr/frontend
 COPY app app
-COPY package-lock.json package.json rollup.config.mjs ./
+COPY package-lock.json package.json rollup.config.mjs .npmrc ./
 
 RUN npm ci --no-audit \
     && npm run build
@@ -99,7 +99,7 @@ COPY --from=python_build --chown=notify:notify /opt/venv /opt/venv
 RUN mkdir -p app
 
 # Install dev/test requirements
-COPY --chown=notify:notify Makefile requirements_for_test.txt package-lock.json package.json rollup.config.mjs ./
+COPY --chown=notify:notify Makefile requirements_for_test.txt package-lock.json package.json rollup.config.mjs .npmrc ./
 RUN make bootstrap
 
 # Copy from the real world, one dir up (project root) into the environment's current working directory


### PR DESCRIPTION
This tells NPM to reject any package version published less than 7 days ago.
Part of the recommendation from the last round of npm supply chain attack.
Available with Node 24 which we already run the app on.

We also want the CI `npm ci` command to have access to

```
ignore-scripts=true
min-release-age=7
````

protections we set in the npm config. To do that, we need to copy the .npmrc file from the repo.

[Tested the config being picked up by CI by adding a "NPM WITH NPRMC into a heading string](https://concourse.notify.tools/teams/pull-requests/pipelines/pull-requests/jobs/build-notifications-admin-pr/builds/1297#L69df6f23:233)
