### PR TITLE
Update govuk-frontend to v 6.2.0

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -1,25 +1,21 @@
-// Version of node_modules/govuk-frontend/components/all.scss specific to Document Download
-// Included to allow us to only include the components we need
 // All imports come from node_modules/govuk-frontend
-
-// set asset URL root to match that of application
-$govuk-assets-path: "/static/";
+@use "base" as * with (
+  $govuk-assets-path: "/static/" // set asset URL root to match that of application
+);
 
 // Dependencies from GOV.UK Frontend
 // https://github.com/alphagov/govuk-frontend
 
-@import "base";
+@use "core";
+@use "objects";
 
-@import "core";
-@import "objects";
+@use "components/button";
+@use "components/error-message";
+@use "components/error-summary";
+@use "components/footer";
+@use "components/header";
+@use "components/input";
+@use "components/skip-link";
 
-@import 'components/button';
-@import 'components/error-message';
-@import 'components/error-summary';
-@import 'components/footer';
-@import 'components/header';
-@import 'components/input';
-@import 'components/skip-link';
-
-@import "utilities";
-@import "overrides/spacing";
+@use "utilities";
+@use "overrides/spacing";

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "govuk-frontend": "6.1.0"
+        "govuk-frontend": "6.2.0"
       },
       "devDependencies": {
         "@eslint/js": "10.0.1",
@@ -2622,9 +2622,9 @@
       "dev": true
     },
     "node_modules/govuk-frontend": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-6.1.0.tgz",
-      "integrity": "sha512-sqivexZFa82LiDIDVMItsUlqEXE/wEUWWBqzEoxHvUFLBH7bY0C8lVrj1qsDThSnj5JEUMS7isBAbKnfQ5Qp6g==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-6.2.0.tgz",
+      "integrity": "sha512-PCRyQT+7kiV2dUz0Ku6Co+Nx4anOwJ7mAduXYbTQHK2krppBSynv9dBXtOYha/8j+LIzK7FqesTbJl9HD6ekHg==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"
@@ -6749,9 +6749,9 @@
       "dev": true
     },
     "govuk-frontend": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-6.1.0.tgz",
-      "integrity": "sha512-sqivexZFa82LiDIDVMItsUlqEXE/wEUWWBqzEoxHvUFLBH7bY0C8lVrj1qsDThSnj5JEUMS7isBAbKnfQ5Qp6g=="
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-6.2.0.tgz",
+      "integrity": "sha512-PCRyQT+7kiV2dUz0Ku6Co+Nx4anOwJ7mAduXYbTQHK2krppBSynv9dBXtOYha/8j+LIzK7FqesTbJl9HD6ekHg=="
     },
     "graceful-fs": {
       "version": "4.2.8",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "Government Digital Service",
   "license": "MIT",
   "dependencies": {
-    "govuk-frontend": "6.1.0"
+    "govuk-frontend": "6.2.0"
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",


### PR DESCRIPTION
Update version which brings in the use of '@use' instead of `@import` which will be deprecated in the next major release. 

Release notes: https://github.com/alphagov/govuk-frontend/releases/tag/v6.2.0

Diff: https://www.diffchecker.com/zdh6Mg1i/ - order is different but inbuilt tool seems to think no other changes

<img width="1071" height="684" alt="Screenshot 2026-06-10 at 09 30 08" src="https://github.com/user-attachments/assets/22c441e3-216a-4cbe-8f92-acd10c78af93" />

